### PR TITLE
fix: doctest compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 [[package]]
 name = "emu"
 version = "0.1.0"
+dependencies = [
+ "emu",
+]
 
 [[package]]
 name = "gb"

--- a/emulators/emu/Cargo.toml
+++ b/emulators/emu/Cargo.toml
@@ -3,4 +3,10 @@ name = "emu"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+test-utilities = []
+
 [dependencies]
+
+[dev-dependencies]
+emu = { path = ".", features = ["test-utilities"] } # this allows us to write doc tests that use the test utilities

--- a/emulators/emu/src/lib.rs
+++ b/emulators/emu/src/lib.rs
@@ -1,5 +1,5 @@
-mod bit_index;
-mod mem;
+pub mod bit_index;
+pub mod mem;
 
 pub use bit_index::{BitIndex, BitIndexOutOfRange};
 pub use mem::MemoryBus;

--- a/emulators/emu/src/mem.rs
+++ b/emulators/emu/src/mem.rs
@@ -1,9 +1,12 @@
 pub trait MemoryBus {
     /// Read a single byte from the given `address`.
     ///
-    /// ## Example
+    /// # Example
+    ///
     /// ```
-    /// let mut bus = Bus::new();
+    /// # use emu::mem::test_utilities::MockMemoryBus;
+    /// # use emu::MemoryBus;
+    /// let mut bus = MockMemoryBus::new(); // implements MemoryBus trait
     ///
     /// bus.write(0x1234, 0x56);
     /// assert_eq!(bus.read(0x1234), 0x56);
@@ -12,9 +15,12 @@ pub trait MemoryBus {
 
     /// Write a single byte to the given `address`.
     ///
-    /// ## Example
-    /// ```no_run
-    /// let mut bus = Bus::new();
+    /// # Example
+    ///
+    /// ```
+    /// # use emu::mem::test_utilities::MockMemoryBus;
+    /// # use emu::MemoryBus;
+    /// let mut bus = MockMemoryBus::new(); // implements MemoryBus trait
     ///
     /// bus.write(0x1234, 0x56);
     /// assert_eq!(bus.read(0x1234), 0x56);
@@ -25,12 +31,15 @@ pub trait MemoryBus {
     ///
     /// The word is assumed to be in little-endian with the low byte at the
     /// given `address` and the high byte at `address` + 1.
-    /// 
+    ///
     /// Note that this function wraps arround in case of overflow.
     ///
-    /// ## Example
+    /// # Example
+    ///
     /// ```
-    /// let mut bus = Bus::new();
+    /// # use emu::mem::test_utilities::MockMemoryBus;
+    /// # use emu::MemoryBus;
+    /// let mut bus = MockMemoryBus::new(); // implements MemoryBus trait
     ///
     /// bus.write(0x1234, 0x56);
     /// bus.write(0x1235, 0x78);
@@ -48,10 +57,13 @@ pub trait MemoryBus {
     /// `address` and the high byte at `address` + 1.
     ///
     /// Note that this function wraps arround in case of overflow.
-    /// 
-    /// ## Example
-    /// ```no_run
-    /// let mut bus = Bus::new();
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use emu::mem::test_utilities::MockMemoryBus;
+    /// # use emu::MemoryBus;
+    /// let mut bus = MockMemoryBus::new(); // implements MemoryBus trait
     ///
     /// bus.write_word(0x1234, 0x5678);
     /// assert_eq!(bus.read(0x1234), 0x78); // low byte
@@ -69,34 +81,40 @@ pub trait MemoryBus {
     }
 }
 
-#[cfg(test)]
-mod tests {
+#[cfg(any(test, feature = "test-utilities"))]
+pub mod test_utilities {
     use super::*;
 
-    struct MockMemoryBus {
-        memory: [u8; 0x10000],
+    pub struct MockMemoryBus {
+        pub mem: [u8; 0x10000],
     }
 
     impl MockMemoryBus {
-        fn new() -> Self {
-            Self {
-                memory: [0; 0x10000],
-            }
+        /// create a fully zero'ed bus
+        pub fn new() -> Self {
+            MockMemoryBus { mem: [0; 0x10000] }
         }
     }
 
     impl MemoryBus for MockMemoryBus {
         fn read(&self, address: u16) -> u8 {
-            self.memory[address as usize]
+            self.mem[address as usize]
         }
 
         fn write(&mut self, address: u16, value: u8) {
-            self.memory[address as usize] = value
+            self.mem[address as usize] = value
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use test_utilities::MockMemoryBus;
 
     #[test]
-    fn memory_bus_read_word() {
+    fn read_word() {
         let mut bus = MockMemoryBus::new();
         bus.write(0x00, 0x34); // lo
         bus.write(0x01, 0x12); // hi
@@ -104,7 +122,7 @@ mod tests {
     }
 
     #[test]
-    fn memory_bus_write_word() {
+    fn write_word() {
         let mut bus = MockMemoryBus::new();
         bus.write_word(0x00, 0x1234);
         assert_eq!(bus.read(0x00), 0x34); // lo
@@ -112,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn memory_bus_write_read_word() {
+    fn write_read_word() {
         let mut bus = MockMemoryBus::new();
         bus.write_word(0x00, 0x1234);
         assert_eq!(bus.read(0x00), 0x34); // lo
@@ -121,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    fn memory_bus_read_range() {
+    fn read_range() {
         let mut bus = MockMemoryBus::new();
         bus.write(0x00, 0x12);
         bus.write(0x01, 0x34);

--- a/emulators/gb/Cargo.toml
+++ b/emulators/gb/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 emu = { path = "../emu" }
+
+[dev-dependencies]
+emu = { path = "../emu", features = ["test-utilities"] }

--- a/emulators/gb/src/cpu.rs
+++ b/emulators/gb/src/cpu.rs
@@ -146,27 +146,8 @@ const HIGH_MEM_OFFSET: u16 = 0xFF00;
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    pub(crate) struct MockBus {
-        pub(crate) mem: [u8; 0x10000],
-    }
-
-    impl MockBus {
-        /// create a fully zero'ed bus
-        pub(crate) fn new() -> Self {
-            MockBus { mem: [0; 0x10000] }
-        }
-    }
-
-    impl MemoryBus for MockBus {
-        fn read(&self, address: u16) -> u8 {
-            self.mem[address as usize]
-        }
-
-        fn write(&mut self, address: u16, value: u8) {
-            self.mem[address as usize] = value
-        }
-    }
+    
+    use emu::mem::test_utilities::MockMemoryBus as MockBus;
 
     #[test]
     fn fetch_byte() {

--- a/emulators/gb/src/cpu.rs
+++ b/emulators/gb/src/cpu.rs
@@ -9,7 +9,7 @@ use stack::StackController;
 
 #[allow(clippy::upper_case_acronyms)] // we're suppressing this lint to keep the naming consistent with the pan docs
 #[derive(Debug, PartialEq, Eq)]
-pub struct CPU {
+pub(crate) struct CPU {
     /// CPU Registers
     registers: Registers,
 
@@ -29,7 +29,7 @@ pub struct CPU {
 }
 
 impl CPU {
-    pub fn new() -> CPU {
+    pub(crate) fn new() -> CPU {
         CPU {
             registers: Registers::new(),
             sp: 0,
@@ -38,7 +38,7 @@ impl CPU {
         }
     }
 
-    pub fn step<M: MemoryBus>(&mut self, mem_bus: &mut M) -> u32 {
+    pub(crate) fn step<M: MemoryBus>(&mut self, mem_bus: &mut M) -> u32 {
         let opcode = self.fetch_byte(mem_bus);
         let cycles = self.execute_instruction(mem_bus, opcode);
         // self.interrupt_check(mem_bus);
@@ -77,7 +77,8 @@ impl CPU {
     /// Read the current byte at `pc` and increment `pc` to the next byte.
     ///
     /// # Example
-    /// ```no_run
+    /// 
+    /// ```ignore
     /// let mut cpu = CPU::new();
     /// let mut bus = Bus::new();
     ///
@@ -89,7 +90,9 @@ impl CPU {
     /// assert_eq!(value, 0x12);
     /// assert_eq!(cpu.pc, 0x0001);
     ///
-    /// // the next call to `fetch` would yield 0x34 and move pc to 0x0002
+    /// let value = cpu.fetch(&bus);
+    /// assert_eq!(value, 0x34);
+    /// assert_eq!(cpu.pc, 0x0002);
     /// ```
     fn fetch_byte<M: MemoryBus>(&mut self, mem_bus: &M) -> u8 {
         let value = mem_bus.read(self.pc);
@@ -97,10 +100,11 @@ impl CPU {
         value
     }
 
-    /// Read the current word at `pc` and increment `pc` to the next word.
+    /// Read the current word pointed by `pc` and move `pc` to the next word.
     ///
     /// # Example
-    /// ```no_run
+    /// 
+    /// ```ignore
     /// let mut cpu = CPU::new();
     /// let mut bus = Bus::new();
     ///
@@ -112,7 +116,9 @@ impl CPU {
     /// assert_eq!(value, 0x1234);
     /// assert_eq!(cpu.pc, 0x0002);
     ///
-    /// // the next call to `fetch_word` would yield 0x5678 and move pc to 0x0004
+    /// let value = cpu.fetch_word(&bus);
+    /// assert_eq!(value, 0x5678);
+    /// assert_eq!(cpu.pc, 0x0004);
     /// ```
     fn fetch_word<M: MemoryBus>(&mut self, mem_bus: &M) -> u16 {
         let value = mem_bus.read_word(self.pc);

--- a/emulators/gb/src/cpu/instructions/dispatch.rs
+++ b/emulators/gb/src/cpu/instructions/dispatch.rs
@@ -150,7 +150,7 @@ impl CPU {
 #[allow(non_snake_case)] // help A LOT to have upper cases for instr names and regs
 mod tests {
     use crate::cpu::IME;
-    use crate::cpu::tests::MockBus as Bus;
+    use emu::mem::test_utilities::MockMemoryBus as Bus;
 
     use super::*;
 

--- a/emulators/gb/src/cpu/instructions/execute.rs
+++ b/emulators/gb/src/cpu/instructions/execute.rs
@@ -1121,7 +1121,7 @@ mod flag_mask {
 #[cfg(test)]
 #[allow(non_snake_case)] // helps a lot for regs names
 mod tests {
-    use crate::cpu::tests::MockBus as Bus;
+    use emu::mem::test_utilities::MockMemoryBus as Bus;
 
     use super::*;
 

--- a/emulators/gb/src/cpu/instructions/operand/operand16.rs
+++ b/emulators/gb/src/cpu/instructions/operand/operand16.rs
@@ -120,7 +120,7 @@ impl From<AddSPe8DstParam> for Operand16 {
 
 #[cfg(test)]
 mod tests {
-    use crate::cpu::tests::MockBus as Bus;
+    use emu::mem::test_utilities::MockMemoryBus as Bus;
 
     use super::*;
 

--- a/emulators/gb/src/cpu/instructions/operand/operand8.rs
+++ b/emulators/gb/src/cpu/instructions/operand/operand8.rs
@@ -154,7 +154,7 @@ impl From<ALU8Param> for Operand8 {
 
 #[cfg(test)]
 mod tests {
-    use crate::cpu::tests::MockBus as Bus;
+    use emu::mem::test_utilities::MockMemoryBus as Bus;
 
     use super::*;
 

--- a/emulators/gb/src/cpu/registers.rs
+++ b/emulators/gb/src/cpu/registers.rs
@@ -38,7 +38,8 @@ impl Registers {
     /// Creates a new [`Registers`] with all registers initialised to `0`.
     ///
     /// # Examples
-    /// ```no_run
+    ///
+    /// ```ignore
     /// let regs = Registers::new();
     /// assert_eq!(regs.a, 0x00);
     /// assert!(!regs.flags.z);
@@ -55,8 +56,9 @@ impl Registers {
     /// For setting the value of `BC` see [`bc_set`](Self::bc_set).
     ///
     /// # Examples
-    /// ```no_run
-    /// let regs = Registers { b: 0x12, c: 0x34 ..Registers::new() };
+    ///
+    /// ```ignore
+    /// let regs = Registers { b: 0x12, c: 0x34, ..Registers::new() };
     ///
     /// assert_eq!(regs.bc_get(), 0x1234);
     /// ```
@@ -72,7 +74,8 @@ impl Registers {
     /// To read the value of `BC` see [`bc_get`](Self::bc_get).
     ///
     /// # Examples
-    /// ```no_run
+    ///
+    /// ```ignore
     /// let mut regs = Registers::new();
     /// regs.bc_set(0x1234);
     ///
@@ -94,8 +97,9 @@ impl Registers {
     /// For setting the value of `DE` see [`de_set`](Self::de_set).
     ///
     /// # Examples
-    /// ```no_run
-    /// let regs = Registers { d: 0x12, e: 0x34 ..Registers::new() };
+    ///
+    /// ```ignore
+    /// let regs = Registers { d: 0x12, e: 0x34, ..Registers::new() };
     ///
     /// assert_eq!(regs.de_get(), 0x1234);
     /// ```
@@ -111,7 +115,8 @@ impl Registers {
     /// To read the value of `DE` see [`de_get`](Self::de_get).
     ///
     /// # Examples
-    /// ```no_run
+    ///
+    /// ```ignore
     /// let mut regs = Registers::new();
     /// regs.de_set(0x1234);
     ///
@@ -133,8 +138,9 @@ impl Registers {
     /// For setting the value of `HL` see [`hl_set`](Self::hl_set).
     ///
     /// # Examples
-    /// ```no_run
-    /// let regs = Registers { h: 0x12, l: 0x34 ..Registers::new() };
+    ///
+    /// ```ignore
+    /// let regs = Registers { h: 0x12, l: 0x34, ..Registers::new() };
     ///
     /// assert_eq!(regs.hl_get(), 0x1234);
     /// ```
@@ -150,7 +156,8 @@ impl Registers {
     /// To read the value of `HL` see [`hl_get`](Self::hl_get).
     ///
     /// # Examples
-    /// ```no_run
+    ///
+    /// ```ignore
     /// let mut regs = Registers::new();
     /// regs.hl_set(0x1234);
     ///
@@ -174,7 +181,8 @@ impl Registers {
     /// For setting the value of `AF` see [`af_set`](Self::af_set).
     ///
     /// # Examples
-    /// ```no_run
+    ///
+    /// ```ignore
     /// let regs = Registers {
     ///     a: 0x12,
     ///     flags: Flags {
@@ -202,7 +210,8 @@ impl Registers {
     /// To read the value of `AF` see [`af_get`](Self::af_get).
     ///
     /// # Examples
-    /// ```no_run
+    ///
+    /// ```ignore
     /// let mut regs = Registers::new();
     /// regs.af_set(0x1200 | 0b1100_1111); // the 4 lower bits are not evaluated for setting `F`
     ///

--- a/emulators/gb/src/cpu/stack.rs
+++ b/emulators/gb/src/cpu/stack.rs
@@ -19,7 +19,8 @@ impl<'a> StackController<'a> {
     /// byte stored at [`Self::sp`] and the high byte at [`Self::sp`] + 1.
     ///
     /// # Example
-    /// ```no_run
+    ///
+    /// ```ignore
     /// let mut cpu = CPU::new();
     /// let mut bus = Bus::new();
     ///
@@ -45,7 +46,8 @@ impl<'a> StackController<'a> {
     /// stack and will just circle around.
     ///
     /// # Example
-    /// ```no_run
+    ///
+    /// ```ignore
     /// let mut cpu = CPU::new();
     /// let mut bus = Bus::new();
     ///

--- a/emulators/gb/src/cpu/stack.rs
+++ b/emulators/gb/src/cpu/stack.rs
@@ -77,7 +77,7 @@ impl<'a> StackController<'a> {
 mod tests {
     use super::*;
 
-    use crate::cpu::tests::MockBus as RAM;
+    use emu::mem::test_utilities::MockMemoryBus as RAM;
 
     struct CPU {
         sp: u16,

--- a/emulators/gb/src/lib.rs
+++ b/emulators/gb/src/lib.rs
@@ -1,7 +1,8 @@
-mod cpu;
+pub(crate) mod cpu;
 // mod motherboard;
 mod mem;
 
+#[derive(Debug)]
 pub struct GameBoy {
     mem: mem::Bus,
     cpu: cpu::CPU,
@@ -53,6 +54,7 @@ impl Default for GameBoy {
     }
 }
 
+#[derive(Debug)]
 pub enum Button {
     A,
     B,

--- a/emulators/gb/src/mem.rs
+++ b/emulators/gb/src/mem.rs
@@ -1,5 +1,6 @@
 use emu::MemoryBus;
 
+#[derive(Debug)]
 pub struct Bus {
     memory: [u8; 0x10000],
 }
@@ -16,7 +17,7 @@ impl MemoryBus for Bus {
     /// Read a single byte from the given address.
     ///
     /// ## Example
-    /// ```
+    /// ```ignore
     /// let mut bus = Bus::new();
     ///
     /// bus.write(0x1234, 0x56);
@@ -29,7 +30,7 @@ impl MemoryBus for Bus {
     /// Write a single byte to the given address.
     ///
     /// ## Example
-    /// ```
+    /// ```ignore
     /// let mut bus = Bus::new();
     ///
     /// bus.write(0x1234, 0x56);
@@ -45,7 +46,7 @@ impl MemoryBus for Bus {
     /// and the byte at the next address (low byte).
     ///
     /// ## Example
-    /// ```
+    /// ```ignore
     /// let mut bus = Bus::new();
     ///
     /// bus.write(0x1234, 0x12);
@@ -64,7 +65,7 @@ impl MemoryBus for Bus {
     /// byte is written to the next address.
     ///
     /// ## Example
-    /// ```
+    /// ```ignore
     /// let mut bus = Bus::new();
     ///
     /// bus.write_word(0x1234, 0x1234);


### PR DESCRIPTION
- fixed doc test compilation for the emu module
- most examples in the CPU module and it's submodule are now `ignore`d as rust doesn't permit the compilation of examples of non-public functions/modules.