### PR TITLE
feat(gb/cpu): implement HALT instruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,11 +83,12 @@ implemented by `MotherBoard`:
 - **`MemoryBus`** (`emulators/emu/src/mem.rs`): `read`/`write` plus little-endian
   `read_word`/`write_word` and `read_range`. CPU methods are generic over
   `M: MemoryBus`.
-- **`InterruptLine`** (`emulators/gb/src/interrupts.rs`): `pending_interrupt` /
-  `acknowledge_interrupt`. The IE/IF registers live in `motherboard/interrupts.rs`.
+- **`InterruptBus`** (`emulators/gb/src/interrupts.rs`): `requested_interrupts` /
+  `enabled_interrupts` / `acknowledge_interrupt`. The IE/IF registers live in
+  `motherboard/interrupts.rs`.
 
 `MotherBoard` (`motherboard.rs`) implements both, so `&mut MotherBoard` satisfies the
-`M: MemoryBus + InterruptLine` bound that `CPU::step` requires. Use the same generic
+`B: MemoryBus + InterruptBus` bound that `CPU::step` requires. Use the same generic
 bounds (rather than a concrete bus) so code stays testable against `MockMemoryBus`.
 
 ### CPU (`emulators/gb/src/cpu.rs` + `cpu/`)
@@ -160,7 +161,7 @@ The decode/execute pipeline is layered:
 - 16-bit memory access is little-endian; addresses/`pc` use `wrapping_add`; high memory
   / I/O registers are based at `0xFF00`.
 - Tests are colocated in `#[cfg(test)]` modules, often with nested topic submodules.
-- Prefer generic `M: MemoryBus (+ InterruptLine)` bounds over concrete bus types so code
+- Prefer generic `M: MemoryBus (+ InterruptBus)` bounds over concrete bus types so code
   can be tested with mocks.
 
 ## Git / contribution workflow

--- a/emulators/gb/src/cpu.rs
+++ b/emulators/gb/src/cpu.rs
@@ -145,7 +145,7 @@ impl CPU {
         }
 
         // Check if an interrupt has been requested to exit the halt state
-        if bus.requested_interrupts().is_empty() {
+        if bus.pending_interrupts().is_empty() {
             Some(HALTED_CYCLES)
         } else {
             self.state.wake();
@@ -259,6 +259,14 @@ mod tests {
                 requested: InterruptFlags::from(interrupt),
                 ..Self::new()
             }
+        }
+
+        pub fn enable_interrupt(&mut self, interrupt: Interrupt) {
+            self.enabled |= InterruptFlags::from(interrupt);
+        }
+
+        pub fn request_interrupt(&mut self, interrupt: Interrupt) {
+            self.requested |= InterruptFlags::from(interrupt);
         }
     }
 
@@ -484,6 +492,27 @@ mod tests {
 
                 assert_eq!(cycles, None);
                 assert_eq!(cpu.state, CPUState::HaltBug);
+            }
+
+            #[test]
+            fn halt_when_not_enabled_interrupt() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::new();
+
+                cpu.state = CPUState::Halted;
+                bus.request_interrupt(Interrupt::LCDStat); // request an interrupt, but don't enable it
+
+                let cycles = cpu.handle_halt(&bus);
+
+                assert_eq!(cycles, Some(HALTED_CYCLES));
+                assert_eq!(cpu.state, CPUState::Halted); // still halted since the interrupt is not enabled
+
+                bus.enable_interrupt(Interrupt::LCDStat); // now enable the interrupt
+
+                let cycles = cpu.handle_halt(&bus);
+
+                assert_eq!(cycles, None);
+                assert_eq!(cpu.state, CPUState::Running); // CPU is now awake since the interrupt is now enabled
             }
 
             #[test]

--- a/emulators/gb/src/cpu.rs
+++ b/emulators/gb/src/cpu.rs
@@ -7,13 +7,11 @@ mod state;
 
 use emu::MemoryBus;
 
-use crate::interrupts::InterruptLine;
+use crate::interrupts::{Interrupt, InterruptBus};
 use interrupts::{IME, INTERRUPT_DISPATCH_CYCLES, InterruptJumpVector};
 use registers::Registers;
 use stack::StackController;
-use state::CPUState;
-
-use instructions::parameter::CallParam;
+use state::{CPUState, HALTED_CYCLES};
 
 #[allow(clippy::upper_case_acronyms)] // we're suppressing this lint to keep the naming consistent with the pan docs
 #[derive(Debug, PartialEq, Eq)]
@@ -56,50 +54,124 @@ impl CPU {
     /// Execute one instruction cycle, including checking for and dispatching any pending interrupts.
     ///
     /// Returns the number of cycles taken to execute the instruction or handle any interrupts.
-    pub(crate) fn step<M: MemoryBus + InterruptLine>(&mut self, mem_bus: &mut M) -> u32 {
-        if let Some(interrupt_cycles) = self.try_dispatch_pending_interrupt(mem_bus) {
-            return interrupt_cycles;
+    pub(crate) fn step<B: MemoryBus + InterruptBus>(&mut self, bus: &mut B) -> u32 {
+        // Halt handling needs to be done before checking for interrupts
+        // since pending interrupts need to be serviced when waking up from halt.
+        if let Some(cycles) = self.handle_halt(bus) {
+            return cycles;
         }
 
+        if let Some(cycles) = self.try_dispatch_pending_interrupt(bus) {
+            return cycles;
+        }
+
+        let opcode = self.fetch_next_opcode(bus);
+
+        let cycles = self.execute_instruction(bus, opcode);
+
+        // Commit any pending IME state changes after executing the instruction
+        // Note that the EI instructions sets the delay to 2 calls to
+        // `commit_pending` as we're taking into account the current call to
+        // `step` and the next one.
         self.ime.commit_pending();
 
-        let opcode = self.fetch_byte(mem_bus);
-        self.execute_instruction(mem_bus, opcode)
+        cycles
     }
 
-    /// Dispatch the highest-priority pending interrupt when IME is enabled.
+    /// Try to dispatch the highest-priority pending interrupt. Returns `None`
+    /// if no interrupt was dispatched or `Some(cycles)` if an interrupt was
+    /// dispatched.
     ///
-    /// Returns the number of cycles taken to handle the interrupt, or `None` if no interrupt was dispatched.
-    ///
-    /// This method will disable IME and acknowledge the interrupt on the bus if an interrupt is dispatched.
-    fn try_dispatch_pending_interrupt<M: MemoryBus + InterruptLine>(
+    /// This method dispatches only if the IME flag is enabled and if an
+    /// interrupt is pending.
+    /// This method will disable IME and acknowledge the interrupt on the bus
+    /// if an interrupt is dispatched.
+    fn try_dispatch_pending_interrupt<B: MemoryBus + InterruptBus>(
         &mut self,
-        mem_bus: &mut M,
+        bus: &mut B,
     ) -> Option<u32> {
         if self.ime != IME::Enabled {
             // IME is not enabled, nothing to do
             return None;
         }
 
-        let Some(pending) = mem_bus.pending_interrupt() else {
+        let Some(interrupt) = bus.highest_pending_interrupt() else {
             // No pending interrupts, nothing to do
             return None;
         };
 
-        self.ime.disable();
-        mem_bus.acknowledge_interrupt(pending);
-
-        self.instr_call(
-            mem_bus,
-            CallParam::VEC(InterruptJumpVector::from(pending).addr()),
-        );
+        self.dispatch_interrupt(bus, interrupt);
 
         Some(INTERRUPT_DISPATCH_CYCLES)
+    }
+
+    /// Dispatch the given interrupt.
+    ///
+    /// This method will disable IME and acknowledge the interrupt on the bus
+    /// and move the program counter to the corresponding interrupt vector.
+    fn dispatch_interrupt<B: MemoryBus + InterruptBus>(
+        &mut self,
+        bus: &mut B,
+        interrupt: Interrupt,
+    ) {
+        self.ime.disable();
+
+        bus.acknowledge_interrupt(interrupt);
+
+        let dst = InterruptJumpVector::from(interrupt).addr();
+        let pc = if self.state.is_halt_bug() {
+            self.state.wake();
+            self.pc.wrapping_sub(1)
+        } else {
+            self.pc
+        };
+
+        self.stack().push_word(bus, pc);
+
+        self.pc = dst;
+    }
+
+    /// Handle the halted state of the CPU.
+    ///
+    /// Wakes if any interrupt is requested, otherwise consumes 4 cycles in the halted state.
+    ///
+    /// Returns `None` if the CPU is not halted and should continue with normal
+    /// instruction dispatch (this includes when the CPU wakes up). Returns
+    /// `Some(cycles)` if the CPU is halted and should consume the given number
+    /// of cycles without dispatching an instruction.
+    fn handle_halt<I: InterruptBus>(&mut self, bus: &I) -> Option<u32> {
+        if !self.state.is_halted() {
+            return None;
+        }
+
+        // Check if an interrupt has been requested to exit the halt state
+        if bus.requested_interrupts().is_empty() {
+            Some(HALTED_CYCLES)
+        } else {
+            self.state.wake();
+            None // wake up; fall through to normal dispatch
+        }
     }
 
     /// Get a stack controller for the CPU's stack pointer.
     const fn stack(&mut self) -> StackController<'_> {
         StackController::new(&mut self.sp)
+    }
+
+    /// Fetch the next opcode to execute.
+    ///
+    /// In the normal case, this will read the byte at the current `pc` and
+    /// increment `pc` by 1.
+    /// However, if the CPU is in the `HaltBug` state, this will read the byte
+    /// at the current `pc` without incrementing `pc`, and then transition the
+    /// CPU back into the `Running` state.
+    fn fetch_next_opcode<B: MemoryBus>(&mut self, bus: &B) -> u8 {
+        if self.state.is_halt_bug() {
+            self.state.wake();
+            bus.read(self.pc)
+        } else {
+            self.fetch_byte(bus)
+        }
     }
 
     /// Read the current byte at `pc` and increment `pc` to the next byte.
@@ -162,30 +234,29 @@ const HIGH_MEM_OFFSET: u16 = 0xFF00;
 mod tests {
     use super::*;
 
-    use crate::interrupts::Interrupt;
+    use crate::interrupts::{Interrupt, InterruptFlags};
     use emu::mem::test_utilities::MockMemoryBus as MockBus;
 
-    /// MockBus implementing InterruptLine trait
-    ///
-    /// It holds only 1 pending interrupt
-    struct MockInterruptBus {
-        mem: MockBus,
-        pending: Option<Interrupt>,
-        acknowledged: Option<Interrupt>,
+    /// `MockBus` implementing `InterruptLine` trait
+    pub struct MockInterruptBus {
+        pub mem: MockBus,
+        pub enabled: InterruptFlags,
+        pub requested: InterruptFlags,
     }
 
     impl MockInterruptBus {
-        fn new() -> Self {
+        pub fn new() -> Self {
             Self {
                 mem: MockBus::new(),
-                pending: None,
-                acknowledged: None,
+                enabled: InterruptFlags::empty(),
+                requested: InterruptFlags::empty(),
             }
         }
 
-        fn with_pending(interrupt: Interrupt) -> Self {
+        pub fn with_pending(interrupt: Interrupt) -> Self {
             Self {
-                pending: Some(interrupt),
+                enabled: InterruptFlags::from(interrupt),
+                requested: InterruptFlags::from(interrupt),
                 ..Self::new()
             }
         }
@@ -197,18 +268,21 @@ mod tests {
         }
 
         fn write(&mut self, address: u16, value: u8) {
-            self.mem.write(address, value)
+            self.mem.write(address, value);
         }
     }
 
-    impl InterruptLine for MockInterruptBus {
-        fn pending_interrupt(&self) -> Option<Interrupt> {
-            self.pending
+    impl InterruptBus for MockInterruptBus {
+        fn requested_interrupts(&self) -> InterruptFlags {
+            self.requested
+        }
+
+        fn enabled_interrupts(&self) -> InterruptFlags {
+            self.enabled
         }
 
         fn acknowledge_interrupt(&mut self, interrupt: Interrupt) {
-            self.acknowledged = Some(interrupt);
-            self.pending = None;
+            self.requested &= !InterruptFlags::from(interrupt);
         }
     }
 
@@ -231,7 +305,7 @@ mod tests {
 
                 cpu.step(&mut bus); // should set IME to PendingEnable
 
-                assert_eq!(cpu.ime, IME::PendingEnable);
+                assert_eq!(cpu.ime, IME::PendingEnable(0));
                 assert_eq!(cpu.pc, 0x0101);
 
                 cpu.step(&mut bus); // noop (bus is zeroed out), but should transition IME to Enabled
@@ -263,14 +337,14 @@ mod tests {
                 assert_eq!(cpu.pc, 0x0100);
                 assert_eq!(cpu.sp, 0xFFFE);
                 assert_eq!(cpu.ime, IME::Disabled);
-                assert_eq!(bus.acknowledged, None);
+                assert_eq!(bus.highest_pending_interrupt(), Some(Interrupt::VBlank));
             }
 
             #[test]
             fn noop_when_ime_pending_enable() {
                 let mut cpu = CPU::new();
                 let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
-                cpu.ime = IME::PendingEnable;
+                cpu.ime = IME::PendingEnable(0);
                 cpu.pc = 0x0100;
                 cpu.sp = 0xFFFE;
 
@@ -279,8 +353,8 @@ mod tests {
                 assert_eq!(cycles, None);
                 assert_eq!(cpu.pc, 0x0100);
                 assert_eq!(cpu.sp, 0xFFFE);
-                assert_eq!(cpu.ime, IME::PendingEnable);
-                assert_eq!(bus.acknowledged, None);
+                assert_eq!(cpu.ime, IME::PendingEnable(0));
+                assert_eq!(bus.highest_pending_interrupt(), Some(Interrupt::VBlank));
             }
 
             #[test]
@@ -297,6 +371,7 @@ mod tests {
                 assert_eq!(cpu.pc, 0x0100);
                 assert_eq!(cpu.sp, 0xFFFE);
                 assert_eq!(cpu.ime, IME::Enabled);
+                assert_eq!(bus.highest_pending_interrupt(), None);
             }
 
             #[test]
@@ -332,7 +407,7 @@ mod tests {
 
                 cpu.try_dispatch_pending_interrupt(&mut bus);
 
-                assert_eq!(bus.acknowledged, Some(Interrupt::Serial));
+                assert_eq!(bus.requested_interrupts(), InterruptFlags::empty());
             }
 
             #[test]
@@ -375,47 +450,397 @@ mod tests {
                 }
             }
         }
+
+        // TODO: missing dispatching using the `step` function
     }
 
-    #[test]
-    fn fetch_byte() {
-        let mut cpu = CPU::new();
-        let mut bus = MockBus::new();
+    mod halt {
+        use super::*;
 
-        cpu.pc = 0xFFFF;
-        bus.mem[0xFFFF] = 0xEF;
-        bus.mem[0x0000] = 0x12;
-        bus.mem[0x0001] = 0x34;
-        bus.mem[0x0002] = 0x56;
+        mod handle_halt {
+            use super::*;
 
-        assert_eq!(cpu.fetch_byte(&bus), 0xEF);
-        assert_eq!(cpu.pc, 0x0000);
-        assert_eq!(cpu.fetch_byte(&bus), 0x12);
-        assert_eq!(cpu.pc, 0x0001);
-        assert_eq!(cpu.fetch_byte(&bus), 0x34);
-        assert_eq!(cpu.pc, 0x0002);
-        assert_eq!(cpu.fetch_byte(&bus), 0x56);
-        assert_eq!(cpu.pc, 0x0003);
+            #[test]
+            fn noop_when_running() {
+                let mut cpu = CPU::new();
+                let bus = MockInterruptBus::new();
+
+                cpu.state = CPUState::Running;
+
+                let cycles = cpu.handle_halt(&bus);
+
+                assert_eq!(cycles, None);
+                assert_eq!(cpu.state, CPUState::Running);
+            }
+
+            #[test]
+            fn noop_when_halt_bug() {
+                let mut cpu = CPU::new();
+                let bus = MockInterruptBus::new();
+
+                cpu.state = CPUState::HaltBug;
+
+                let cycles = cpu.handle_halt(&bus);
+
+                assert_eq!(cycles, None);
+                assert_eq!(cpu.state, CPUState::HaltBug);
+            }
+
+            #[test]
+            fn wake_on_pending_interrupt() {
+                let mut cpu = CPU::new();
+                let bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.state = CPUState::Halted;
+
+                let cycles = cpu.handle_halt(&bus);
+
+                assert_eq!(cycles, None);
+                assert_eq!(cpu.state, CPUState::Running); // CPU is now awake
+            }
+
+            #[test]
+            fn consume_cycles_when_no_pending_interrupt() {
+                let mut cpu = CPU::new();
+                let bus = MockInterruptBus::new();
+
+                cpu.state = CPUState::Halted;
+
+                let cycles = cpu.handle_halt(&bus);
+
+                assert_eq!(cycles, Some(HALTED_CYCLES));
+                assert_eq!(cpu.state, CPUState::Halted);
+            }
+        }
+
+        mod step {
+            use super::*;
+
+            #[test]
+            fn consume_cycles_when_no_pending_interrupt() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::new();
+
+                cpu.ime = IME::Enabled;
+                cpu.state = CPUState::Halted;
+
+                let cycles = cpu.step(&mut bus);
+
+                assert_eq!(cycles, HALTED_CYCLES); // CPU is still halted
+                assert_eq!(cpu.state, CPUState::Halted);
+                assert_eq!(cpu.pc, 0x0000); // PC should not have changed
+            }
+
+            #[test]
+            fn wake_on_pending_interrupt() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.ime = IME::Enabled;
+                cpu.state = CPUState::Halted;
+
+                let cycles = cpu.step(&mut bus);
+
+                assert_eq!(cycles, INTERRUPT_DISPATCH_CYCLES); // interrupt was dispatched
+                assert_eq!(cpu.state, CPUState::Running); // CPU is now awake
+                assert_eq!(cpu.pc, 0x0040); // VBlank interrupt vector
+            }
+
+            #[test]
+            fn wake_on_ime_disabled_pending_interrupt() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.pc = 0x0100;
+
+                cpu.state = CPUState::Halted;
+                cpu.ime = IME::Disabled;
+
+                let cycles = cpu.step(&mut bus);
+
+                // executes the noop instruction under PC 0x0100 since everything is zeroed out
+
+                assert_eq!(cycles, 4); // instr noop cycles
+                assert_eq!(cpu.state, CPUState::Running); // CPU is now awake
+                assert_eq!(cpu.pc, 0x0101); // PC is incremented to the next instruction after executing the noop
+            }
+        }
+
+        mod halt_bug {
+            use super::*;
+
+            #[test]
+            fn halt_bug() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.pc = 0x0100;
+                cpu.state = CPUState::HaltBug;
+                cpu.ime = IME::Disabled;
+
+                let cycles = cpu.step(&mut bus);
+
+                assert_eq!(cycles, 4); // instr noop cycles
+                assert_eq!(cpu.state, CPUState::Running); // CPU is now awake
+                assert_eq!(cpu.pc, 0x0100); // PC isn't incremented due to halt bug behavior
+            }
+
+            #[test]
+            fn halt_bug_inc_twice() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.pc = 0x0100;
+                cpu.state = CPUState::Running;
+                cpu.ime = IME::Disabled;
+
+                bus.write(0x0100, 0x76); // HALT opcode
+                bus.write(0x0101, 0x04); // INC B opcode
+
+                cpu.step(&mut bus); // HALT instruction
+
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now in halt bug state
+                assert_eq!(cpu.pc, 0x0101); // PC is at the following instruction
+
+                cpu.step(&mut bus); // INC B instruction
+
+                assert_eq!(cpu.registers.b, 0x01); // B register should have been incremented
+                assert_eq!(cpu.state, CPUState::Running); // CPU is now awake
+                assert_eq!(cpu.pc, 0x0101); // PC remains the same due to halt bug behavior
+
+                cpu.step(&mut bus); // INC B instruction again
+
+                assert_eq!(cpu.registers.b, 0x02); // B register should have been incremented again
+                assert_eq!(cpu.pc, 0x0102); // PC moves to the next instruction after INC B, as halt bug behavior should be resolved after the first instruction following HALT is executed
+            }
+
+            #[test]
+            fn halt_bug_changes_param_values() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.pc = 0x0100;
+                cpu.state = CPUState::Running;
+                cpu.ime = IME::Disabled;
+
+                bus.write(0x0100, 0x76); // HALT opcode
+                bus.write(0x0101, 0x06); // LD B, n opcode
+                bus.write(0x0102, 0x04); // value 0x04 to be loaded into B register
+
+                cpu.step(&mut bus); // HALT instruction
+
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now in halt bug state
+                assert_eq!(cpu.pc, 0x0101); // PC is at the following instruction
+
+                cpu.step(&mut bus); // LD B, n instruction
+
+                assert_eq!(cpu.registers.b, 0x06); // B register should have been loaded with the value of the next instruction (0x06) instead of the intended value (0x04) due to halt bug behavior where PC is not incremented after the first instruction following HALT
+                assert_eq!(cpu.state, CPUState::Running); // CPU is now awake
+                assert_eq!(cpu.pc, 0x0102); // PC increments only once from fetching the parameter of the instruction
+
+                cpu.step(&mut bus); // Parameter 0x04 is now executed as an instruction instead of being loaded into B register
+
+                assert_eq!(cpu.registers.b, 0x07); // B is instead incremented by the INC B instruction (opcode 0x04)
+                assert_eq!(cpu.pc, 0x0103); // PC increments normaly to the next instruction
+            }
+
+            #[test]
+            fn halt_bug_pushes_incorect_return_address() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.pc = 0x0100;
+                cpu.state = CPUState::Running;
+                cpu.ime = IME::Disabled;
+
+                bus.write(0x0100, 0x76); // HALT opcode
+                bus.write(0x0101, 0xCF); // RST $08 opcode (call to address 0x08)
+
+                cpu.step(&mut bus); // HALT instruction
+
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now in halt bug state
+                assert_eq!(cpu.pc, 0x0101); // PC is at the following instruction
+
+                cpu.step(&mut bus); // RST $08 instruction
+
+                assert_eq!(cpu.pc, 0x08); // PC should have jumped to the called address
+                assert_eq!(cpu.stack().peek_word(&bus), 0x0101); // The return address pushed onto the stack should be the address of the RST $08 instruction (0x0101) instead of the next instruction after 0x0102.
+            }
+
+            #[test]
+            fn ei_into_halt_bug() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.pc = 0x0100;
+                cpu.state = CPUState::Running;
+                cpu.ime = IME::Disabled;
+
+                bus.write(0x0100, 0xFB); // EI opcode
+                bus.write(0x0101, 0x76); // HALT opcode -- halt is called before IME is fully enabled with an interrupt pending -> halt bug occurs
+                bus.write(0x0040, 0x00); // VBlank interrupt vector -- noop to execute after the interrupt is dispatched
+                bus.write(0x0041, 0xD9); // RETI opcode -- return from interrupt
+
+                let cycles = cpu.step(&mut bus); // EI instruction
+
+                assert_eq!(cycles, 4); // EI instruction cycles
+                assert_eq!(cpu.ime, IME::PendingEnable(0));
+                assert_eq!(cpu.pc, 0x0101); // PC is now at the HALT instruction
+
+                let cycles = cpu.step(&mut bus); // HALT instruction
+
+                assert_eq!(cycles, 4); // HALT instruction cycles
+                assert_eq!(cpu.ime, IME::Enabled); // IME is now enabled
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now in halt bug state
+                assert_eq!(cpu.pc, 0x0102); // PC is after the HALT instruction
+
+                let cycles = cpu.step(&mut bus); // Dispatch the pending VBlank interrupt
+
+                assert_eq!(cycles, INTERRUPT_DISPATCH_CYCLES); // interrupt was dispatched
+                assert_eq!(cpu.ime, IME::Disabled); // IME is now disabled
+                assert_eq!(cpu.state, CPUState::Running); // CPU is still in halt bug state
+                assert_eq!(cpu.pc, 0x0040); // PC is now at the VBlank interrupt vector
+                assert_eq!(cpu.stack().peek_word(&bus), 0x0101); // The return address pushed onto the stack should be the address of the HALT instruction (0x0101) instead of the next instruction due to halt bug behavior
+
+                let cycles = cpu.step(&mut bus); // Execute the noop at the VBlank interrupt vector
+
+                assert_eq!(cycles, 4); // noop instruction cycles
+                assert_eq!(cpu.pc, 0x0041); // PC is now at the next instruction after the VBlank interrupt vector
+
+                let cycles = cpu.step(&mut bus); // Execute the RETI instruction
+
+                assert_eq!(cycles, 16); // RETI instruction cycles
+                assert_eq!(cpu.ime, IME::Enabled); // IME is now enabled through RETI instruction
+                assert_eq!(cpu.pc, 0x0101); // PC is now back at the HALT instruction after returning from the interrupt due to earlier halt bug
+
+                let cycles = cpu.step(&mut bus); // Execute the HALT instruction again
+
+                assert_eq!(cycles, 4); // HALT instruction cycles
+                assert_eq!(cpu.state, CPUState::Halted); // CPU is now properly halted
+            }
+
+            /// Chaining 2 halts with a pending interrupt and IME disabled
+            /// should result in a dead lock where the second halt instruction
+            /// is called repeatedly.
+            #[test]
+            fn double_halt_bug_deadlock() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::with_pending(Interrupt::VBlank);
+
+                cpu.pc = 0x0100;
+                cpu.state = CPUState::Running;
+                cpu.ime = IME::Disabled;
+
+                bus.write(0x0100, 0x76); // HALT opcode
+                bus.write(0x0101, 0x76); // HALT opcode
+
+                cpu.step(&mut bus); // 1st HALT instruction
+
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now awake due to halt bug behavior
+                assert_eq!(cpu.pc, 0x0101); // PC is still at the HALT instruction due to halt bug behavior
+
+                cpu.step(&mut bus); // Execute the HALT instruction again
+
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now properly halted
+                assert_eq!(cpu.pc, 0x0101); // PC is now at the next instruction after the first HALT
+
+                cpu.step(&mut bus); // Execute the HALT instruction again
+
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now properly halted
+                assert_eq!(cpu.pc, 0x0101); // PC is now at the next instruction after the first HALT
+
+                cpu.step(&mut bus); // Execute the HALT instruction again
+
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now properly halted
+                assert_eq!(cpu.pc, 0x0101); // PC is now at the next instruction after the first HALT
+            }
+        }
     }
 
-    #[test]
-    fn fetch_word() {
-        let mut cpu = CPU::new();
-        let mut bus = MockBus::new();
+    mod fetch {
+        use super::*;
 
-        cpu.pc = 0xFFFE;
-        bus.mem[0xFFFE] = 0xEF; // lo
-        bus.mem[0xFFFF] = 0xCD; // hi
-        bus.mem[0x0000] = 0x34; // lo
-        bus.mem[0x0001] = 0x12; // hi
-        bus.mem[0x0002] = 0x78; // lo
-        bus.mem[0x0003] = 0x56; // hi
+        #[test]
+        fn fetch_next_opcode_halt_bug() {
+            let mut cpu = CPU::new();
+            let mut bus = MockBus::new();
 
-        assert_eq!(cpu.fetch_word(&bus), 0xCDEF);
-        assert_eq!(cpu.pc, 0x0000);
-        assert_eq!(cpu.fetch_word(&bus), 0x1234);
-        assert_eq!(cpu.pc, 0x0002);
-        assert_eq!(cpu.fetch_word(&bus), 0x5678);
-        assert_eq!(cpu.pc, 0x0004);
+            cpu.pc = 0x0000;
+            bus.mem[0x0000] = 0x12;
+            bus.mem[0x0001] = 0x34;
+
+            cpu.state = CPUState::HaltBug;
+
+            let opcode1 = cpu.fetch_next_opcode(&bus);
+            assert_eq!(opcode1, 0x12);
+            assert_eq!(cpu.pc, 0x0000); // PC should not have incremented due to halt bug
+            assert_eq!(cpu.state, CPUState::Running); // CPU should have woken up from halt bug state
+
+            let opcode2 = cpu.fetch_next_opcode(&bus);
+            assert_eq!(opcode2, 0x12); // should fetch the same opcode again due to halt bug
+            assert_eq!(cpu.pc, 0x0001); // PC should still not have incremented
+        }
+
+        #[test]
+        fn fetch_next_opcode_normal() {
+            let mut cpu = CPU::new();
+            let mut bus = MockBus::new();
+
+            cpu.pc = 0x0000;
+            bus.mem[0x0000] = 0x12;
+            bus.mem[0x0001] = 0x34;
+
+            cpu.state = CPUState::Running;
+
+            let opcode1 = cpu.fetch_next_opcode(&bus);
+            assert_eq!(opcode1, 0x12);
+            assert_eq!(cpu.pc, 0x0001); // PC should have incremented
+
+            let opcode2 = cpu.fetch_next_opcode(&bus);
+            assert_eq!(opcode2, 0x34);
+            assert_eq!(cpu.pc, 0x0002); // PC should have incremented again
+        }
+
+        #[test]
+        fn fetch_byte() {
+            let mut cpu = CPU::new();
+            let mut bus = MockBus::new();
+
+            cpu.pc = 0xFFFF;
+            bus.mem[0xFFFF] = 0xEF;
+            bus.mem[0x0000] = 0x12;
+            bus.mem[0x0001] = 0x34;
+            bus.mem[0x0002] = 0x56;
+
+            assert_eq!(cpu.fetch_byte(&bus), 0xEF);
+            assert_eq!(cpu.pc, 0x0000);
+            assert_eq!(cpu.fetch_byte(&bus), 0x12);
+            assert_eq!(cpu.pc, 0x0001);
+            assert_eq!(cpu.fetch_byte(&bus), 0x34);
+            assert_eq!(cpu.pc, 0x0002);
+            assert_eq!(cpu.fetch_byte(&bus), 0x56);
+            assert_eq!(cpu.pc, 0x0003);
+        }
+
+        #[test]
+        fn fetch_word() {
+            let mut cpu = CPU::new();
+            let mut bus = MockBus::new();
+
+            cpu.pc = 0xFFFE;
+            bus.mem[0xFFFE] = 0xEF; // lo
+            bus.mem[0xFFFF] = 0xCD; // hi
+            bus.mem[0x0000] = 0x34; // lo
+            bus.mem[0x0001] = 0x12; // hi
+            bus.mem[0x0002] = 0x78; // lo
+            bus.mem[0x0003] = 0x56; // hi
+
+            assert_eq!(cpu.fetch_word(&bus), 0xCDEF);
+            assert_eq!(cpu.pc, 0x0000);
+            assert_eq!(cpu.fetch_word(&bus), 0x1234);
+            assert_eq!(cpu.pc, 0x0002);
+            assert_eq!(cpu.fetch_word(&bus), 0x5678);
+            assert_eq!(cpu.pc, 0x0004);
+        }
     }
 }

--- a/emulators/gb/src/cpu.rs
+++ b/emulators/gb/src/cpu.rs
@@ -594,6 +594,38 @@ mod tests {
                 assert_eq!(cpu.state, CPUState::Running); // CPU is now awake
                 assert_eq!(cpu.pc, 0x0101); // PC is incremented to the next instruction after executing the noop
             }
+
+            #[test]
+            fn ei_into_halt() {
+                let mut cpu = CPU::new();
+                let mut bus = MockInterruptBus::new();
+
+                bus.enable_interrupt(Interrupt::Joypad);
+
+                cpu.pc = 0x0100;
+
+                bus.write(0x0100, 0xFB); // EI opcode
+                bus.write(0x0101, 0x76); // HALT opcode
+
+                cpu.step(&mut bus); // enable ime
+
+                assert_eq!(cpu.ime, IME::PendingEnable(0));
+                assert_eq!(cpu.pc, 0x0101);
+
+                cpu.step(&mut bus); // halt instruction
+
+                assert_eq!(cpu.state, CPUState::Halted);
+                assert_eq!(cpu.ime, IME::Enabled); // IME should now be enabled after the EI instruction's delay
+                assert_eq!(cpu.pc, 0x0102);
+
+                bus.request_interrupt(Interrupt::Joypad); // request an interrupt to wake the CPU
+
+                let cycles = cpu.step(&mut bus); // should wake the CPU
+
+                assert_eq!(cycles, INTERRUPT_DISPATCH_CYCLES);
+                assert_eq!(cpu.state, CPUState::Running);
+                assert_eq!(cpu.pc, 0x0060); // Joypad interrupt vector
+            }
         }
 
         mod halt_bug {

--- a/emulators/gb/src/cpu.rs
+++ b/emulators/gb/src/cpu.rs
@@ -56,7 +56,7 @@ impl CPU {
     /// Returns the number of cycles taken to execute the instruction or handle any interrupts.
     pub(crate) fn step<B: MemoryBus + InterruptBus>(&mut self, bus: &mut B) -> u32 {
         // Halt handling needs to be done before checking for interrupts
-        // since pending interrupts need to be serviced when waking up from halt.
+        // since pending interrupts need to be serviced on wake up from halt.
         if let Some(cycles) = self.handle_halt(bus) {
             return cycles;
         }
@@ -69,11 +69,11 @@ impl CPU {
 
         let cycles = self.execute_instruction(bus, opcode);
 
-        // Commit any pending IME state changes after executing the instruction
+        // Tick the IME flag after executing the instruction
         // Note that the EI instructions sets the delay to 2 calls to
-        // `commit_pending` as we're taking into account the current call to
+        // `ime.tick()` as we're taking into account the current call to
         // `step` and the next one.
-        self.ime.commit_pending();
+        self.ime.tick();
 
         cycles
     }
@@ -133,7 +133,8 @@ impl CPU {
 
     /// Handle the halted state of the CPU.
     ///
-    /// Wakes if any interrupt is requested, otherwise consumes 4 cycles in the halted state.
+    /// Wakes if any enabled interrupt is requested, otherwise consumes 4 cycles
+    /// in the halted state.
     ///
     /// Returns `None` if the CPU is not halted and should continue with normal
     /// instruction dispatch (this includes when the CPU wakes up). Returns
@@ -144,7 +145,7 @@ impl CPU {
             return None;
         }
 
-        // Check if an interrupt has been requested to exit the halt state
+        // Check if an interrupt is pending to exit the halt state
         if bus.pending_interrupts().is_empty() {
             Some(HALTED_CYCLES)
         } else {
@@ -765,22 +766,22 @@ mod tests {
 
                 cpu.step(&mut bus); // 1st HALT instruction
 
-                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now awake due to halt bug behavior
-                assert_eq!(cpu.pc, 0x0101); // PC is still at the HALT instruction due to halt bug behavior
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is in halt bug state
+                assert_eq!(cpu.pc, 0x0101); // PC is at the next instruction after the first HALT
+
+                cpu.step(&mut bus); // Execute the 2nd HALT instruction
+
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is kept in halt bug state due to the second HALT
+                assert_eq!(cpu.pc, 0x0101); // PC stays on the second HALT instruction due to halt bug behavior
 
                 cpu.step(&mut bus); // Execute the HALT instruction again
 
-                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now properly halted
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU remains in halt bug state
                 assert_eq!(cpu.pc, 0x0101); // PC is now at the next instruction after the first HALT
 
                 cpu.step(&mut bus); // Execute the HALT instruction again
 
-                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now properly halted
-                assert_eq!(cpu.pc, 0x0101); // PC is now at the next instruction after the first HALT
-
-                cpu.step(&mut bus); // Execute the HALT instruction again
-
-                assert_eq!(cpu.state, CPUState::HaltBug); // CPU is now properly halted
+                assert_eq!(cpu.state, CPUState::HaltBug); // CPU remains in halt bug state
                 assert_eq!(cpu.pc, 0x0101); // PC is now at the next instruction after the first HALT
             }
         }

--- a/emulators/gb/src/cpu.rs
+++ b/emulators/gb/src/cpu.rs
@@ -3,6 +3,7 @@ mod instructions;
 mod interrupts;
 mod registers;
 mod stack;
+mod state;
 
 use emu::MemoryBus;
 
@@ -10,6 +11,7 @@ use crate::interrupts::InterruptLine;
 use interrupts::{IME, INTERRUPT_DISPATCH_CYCLES, InterruptJumpVector};
 use registers::Registers;
 use stack::StackController;
+use state::CPUState;
 
 use instructions::parameter::CallParam;
 
@@ -30,17 +32,24 @@ pub struct CPU {
     pc: u16,
 
     /// Interrupt Master Enable flag
+    ///
+    /// Controls whether the CPU will jump to interrupt vectors when an interrupt is requested.
     ime: IME,
-    // state: CPUState, // for HALT and STOP states?
+
+    /// Current state of the CPU
+    ///
+    /// Used to manage halting and stopping behavior.
+    state: CPUState,
 }
 
 impl CPU {
     pub(crate) fn new() -> Self {
         Self {
             registers: Registers::new(),
-            sp: 0,
-            pc: 0,
+            sp: 0x00,
+            pc: 0x00,
             ime: IME::Disabled,
+            state: CPUState::Running,
         }
     }
 
@@ -60,7 +69,7 @@ impl CPU {
 
     /// Dispatch the highest-priority pending interrupt when IME is enabled.
     ///
-    /// Returns the number of cycles taken to handle the interrupt, or 0 if no interrupt was dispatched.
+    /// Returns the number of cycles taken to handle the interrupt, or `None` if no interrupt was dispatched.
     ///
     /// This method will disable IME and acknowledge the interrupt on the bus if an interrupt is dispatched.
     fn try_dispatch_pending_interrupt<M: MemoryBus + InterruptLine>(
@@ -68,10 +77,12 @@ impl CPU {
         mem_bus: &mut M,
     ) -> Option<u32> {
         if self.ime != IME::Enabled {
+            // IME is not enabled, nothing to do
             return None;
         }
 
         let Some(pending) = mem_bus.pending_interrupt() else {
+            // No pending interrupts, nothing to do
             return None;
         };
 

--- a/emulators/gb/src/cpu/instructions/dispatch.rs
+++ b/emulators/gb/src/cpu/instructions/dispatch.rs
@@ -1,4 +1,5 @@
 use crate::cpu::CPU;
+use crate::interrupts::InterruptBus;
 
 use super::condition::Condition;
 use super::meta;
@@ -11,94 +12,96 @@ use emu::MemoryBus;
 impl CPU {
     /// Dispatch and execute an instruction from the main instruction table
     /// designated by `opcode`.
-    pub(crate) fn execute_instruction<M: MemoryBus>(&mut self, mem_bus: &mut M, opcode: u8) -> u32 {
+    pub(crate) fn execute_instruction<B: MemoryBus + InterruptBus>(
+        &mut self,
+        bus: &mut B,
+        opcode: u8,
+    ) -> u32 {
         let additional_cycles = match opcode {
             0x00 => {
                 // NOP
                 0
             }
-            0x01 | 0x11 | 0x21 | 0x31 => self.instr_ld16(
-                mem_bus,
-                R16Param::from(opcode >> 4).into(),
-                LD16SrcParam::N16,
-            ),
+            0x01 | 0x11 | 0x21 | 0x31 => {
+                self.instr_ld16(bus, R16Param::from(opcode >> 4).into(), LD16SrcParam::N16)
+            }
             0x02 | 0x12 | 0x22 | 0x32 => self.instr_ld8(
-                mem_bus,
+                bus,
                 R16MemParam::from(opcode >> 4).into(),
                 R8Param::A.into(),
             ),
-            0x03 | 0x13 | 0x23 | 0x33 => self.instr_inc16(mem_bus, R16Param::from(opcode >> 4)),
+            0x03 | 0x13 | 0x23 | 0x33 => self.instr_inc16(bus, R16Param::from(opcode >> 4)),
             0x04 | 0x0C | 0x14 | 0x1C | 0x24 | 0x2C | 0x34 | 0x3C => {
-                self.instr_inc8(mem_bus, R8Param::from(opcode >> 3))
+                self.instr_inc8(bus, R8Param::from(opcode >> 3))
             }
             0x05 | 0x0D | 0x15 | 0x1D | 0x25 | 0x2D | 0x35 | 0x3D => {
-                self.instr_dec8(mem_bus, R8Param::from(opcode >> 3))
+                self.instr_dec8(bus, R8Param::from(opcode >> 3))
             }
             0x06 | 0x0E | 0x16 | 0x1E | 0x26 | 0x2E | 0x36 | 0x3E => {
-                self.instr_ld8(mem_bus, R8Param::from(opcode >> 3).into(), LD8SrcParam::N8)
+                self.instr_ld8(bus, R8Param::from(opcode >> 3).into(), LD8SrcParam::N8)
             }
             0x07 | 0x0F | 0x17 | 0x1F => {
-                self.instr_rotate_acc(mem_bus, BitRotateOperation::from(opcode >> 3))
+                self.instr_rotate_acc(bus, BitRotateOperation::from(opcode >> 3))
             }
-            0x08 => self.instr_ld16(mem_bus, LD16DstParam::IndN16, LD16SrcParam::SP),
-            0x09 | 0x19 | 0x29 | 0x39 => self.instr_add16(mem_bus, R16Param::from(opcode >> 4)),
+            0x08 => self.instr_ld16(bus, LD16DstParam::IndN16, LD16SrcParam::SP),
+            0x09 | 0x19 | 0x29 | 0x39 => self.instr_add16(bus, R16Param::from(opcode >> 4)),
             0x0A | 0x1A | 0x2A | 0x3A => self.instr_ld8(
-                mem_bus,
+                bus,
                 R8Param::A.into(),
                 R16MemParam::from(opcode >> 4).into(),
             ),
-            0x0B | 0x1B | 0x2B | 0x3B => self.instr_dec16(mem_bus, R16Param::from(opcode >> 4)),
+            0x0B | 0x1B | 0x2B | 0x3B => self.instr_dec16(bus, R16Param::from(opcode >> 4)),
             0x10 => self.instr_stop(),
-            0x18 => self.instr_jump(mem_bus, JumpParam::PCE8),
+            0x18 => self.instr_jump(bus, JumpParam::PCE8),
             0x20 | 0x28 | 0x30 | 0x38 => {
-                self.instr_cond_jump(mem_bus, Condition::from(opcode >> 3), JumpParam::PCE8)
+                self.instr_cond_jump(bus, Condition::from(opcode >> 3), JumpParam::PCE8)
             }
             0x27 => self.instr_daa(),
             0x2F => self.instr_cpl(),
             0x37 => self.instr_scf(),
             0x3F => self.instr_ccf(),
-            0x76 => self.instr_halt(),
+            0x76 => self.instr_halt(bus),
             0x40..=0x7F => self.instr_ld8(
-                mem_bus,
+                bus,
                 R8Param::from(opcode >> 3).into(),
                 R8Param::from(opcode).into(),
             ),
             0x80..=0xBF => self.instr_alu(
-                mem_bus,
+                bus,
                 ALUOperation::from(opcode >> 3),
                 R8Param::from(opcode).into(),
             ),
-            0xC0 | 0xC8 | 0xD0 | 0xD8 => self.instr_cond_ret(mem_bus, Condition::from(opcode >> 3)),
-            0xC1 | 0xD1 | 0xE1 | 0xF1 => self.instr_pop(mem_bus, R16StackParam::from(opcode >> 4)),
+            0xC0 | 0xC8 | 0xD0 | 0xD8 => self.instr_cond_ret(bus, Condition::from(opcode >> 3)),
+            0xC1 | 0xD1 | 0xE1 | 0xF1 => self.instr_pop(bus, R16StackParam::from(opcode >> 4)),
             0xC2 | 0xCA | 0xD2 | 0xDA => {
-                self.instr_cond_jump(mem_bus, Condition::from(opcode >> 3), JumpParam::N16)
+                self.instr_cond_jump(bus, Condition::from(opcode >> 3), JumpParam::N16)
             }
-            0xC3 => self.instr_jump(mem_bus, JumpParam::N16),
+            0xC3 => self.instr_jump(bus, JumpParam::N16),
             0xC4 | 0xCC | 0xD4 | 0xDC => {
-                self.instr_cond_call(mem_bus, Condition::from(opcode >> 3), CallParam::N16)
+                self.instr_cond_call(bus, Condition::from(opcode >> 3), CallParam::N16)
             }
-            0xC5 | 0xD5 | 0xE5 | 0xF5 => self.instr_push(mem_bus, R16StackParam::from(opcode >> 4)),
+            0xC5 | 0xD5 | 0xE5 | 0xF5 => self.instr_push(bus, R16StackParam::from(opcode >> 4)),
             0xC6 | 0xCE | 0xD6 | 0xDE | 0xE6 | 0xEE | 0xF6 | 0xFE => {
-                self.instr_alu(mem_bus, ALUOperation::from(opcode >> 3), ALU8Param::N8)
+                self.instr_alu(bus, ALUOperation::from(opcode >> 3), ALU8Param::N8)
             }
             0xC7 | 0xCF | 0xD7 | 0xDF | 0xE7 | 0xEF | 0xF7 | 0xFF => {
-                self.instr_call(mem_bus, CallParam::VEC(u16::from(opcode) & 0b0011_1000))
+                self.instr_call(bus, CallParam::VEC(u16::from(opcode) & 0b0011_1000))
             }
-            0xC9 => self.instr_ret(mem_bus),
-            0xCB => self.instr_prefix(mem_bus),
-            0xCD => self.instr_call(mem_bus, CallParam::N16),
-            0xD9 => self.instr_reti(mem_bus),
-            0xE0 => self.instr_ld8(mem_bus, LD8DstParam::IndHighMemA8, R8Param::A.into()),
-            0xE2 => self.instr_ld8(mem_bus, LD8DstParam::IndHighMemC, R8Param::A.into()),
-            0xE8 => self.instr_add_spe8(mem_bus, AddSPe8DstParam::SP),
-            0xE9 => self.instr_jump(mem_bus, JumpParam::HL),
-            0xEA => self.instr_ld8(mem_bus, LD8DstParam::IndN16, R8Param::A.into()),
-            0xF0 => self.instr_ld8(mem_bus, R8Param::A.into(), LD8SrcParam::IndHighMemA8),
-            0xF2 => self.instr_ld8(mem_bus, R8Param::A.into(), LD8SrcParam::IndHighMemC),
+            0xC9 => self.instr_ret(bus),
+            0xCB => self.instr_prefix(bus),
+            0xCD => self.instr_call(bus, CallParam::N16),
+            0xD9 => self.instr_reti(bus),
+            0xE0 => self.instr_ld8(bus, LD8DstParam::IndHighMemA8, R8Param::A.into()),
+            0xE2 => self.instr_ld8(bus, LD8DstParam::IndHighMemC, R8Param::A.into()),
+            0xE8 => self.instr_add_spe8(bus, AddSPe8DstParam::SP),
+            0xE9 => self.instr_jump(bus, JumpParam::HL),
+            0xEA => self.instr_ld8(bus, LD8DstParam::IndN16, R8Param::A.into()),
+            0xF0 => self.instr_ld8(bus, R8Param::A.into(), LD8SrcParam::IndHighMemA8),
+            0xF2 => self.instr_ld8(bus, R8Param::A.into(), LD8SrcParam::IndHighMemC),
             0xF3 => self.instr_di(),
-            0xF8 => self.instr_add_spe8(mem_bus, AddSPe8DstParam::HL),
-            0xF9 => self.instr_ld16(mem_bus, R16Param::SP.into(), LD16SrcParam::HL),
-            0xFA => self.instr_ld8(mem_bus, R8Param::A.into(), LD8SrcParam::IndN16),
+            0xF8 => self.instr_add_spe8(bus, AddSPe8DstParam::HL),
+            0xF9 => self.instr_ld16(bus, R16Param::SP.into(), LD16SrcParam::HL),
+            0xFA => self.instr_ld8(bus, R8Param::A.into(), LD8SrcParam::IndN16),
             0xFB => self.instr_ei(),
 
             0xD3 | 0xE3 | 0xE4 | 0xF4 | 0xDB | 0xEB | 0xEC | 0xFC | 0xDD | 0xED | 0xFD => {
@@ -152,7 +155,8 @@ impl CPU {
 #[allow(non_snake_case)] // help A LOT to have upper cases for instr names and regs
 mod tests {
     use crate::cpu::interrupts::IME;
-    use emu::mem::test_utilities::MockMemoryBus as Bus;
+    use crate::cpu::state::CPUState;
+    use crate::cpu::tests::MockInterruptBus as Bus;
 
     use super::*;
 
@@ -236,12 +240,12 @@ mod tests {
 
             cpu.registers.h = 0x12;
             cpu.registers.l = 0x34;
-            bus.mem[0x1234] = 0x56;
+            bus.write(0x1234, 0x56);
             let cycles = cpu.execute_instruction(&mut bus, 0x6E); // LD L [HL]
 
             assert_eq!(cycles, 8);
             assert_eq!(cpu.registers.l, 0x56);
-            assert_eq!(bus.mem[0x1234], 0x56);
+            assert_eq!(bus.read(0x1234), 0x56);
         }
 
         #[test]
@@ -251,12 +255,12 @@ mod tests {
 
             cpu.registers.h = 0x12;
             cpu.registers.l = 0x34;
-            bus.mem[0x1234] = 0x56;
+            bus.write(0x1234, 0x56);
             cpu.registers.a = 0x01;
             let cycles = cpu.execute_instruction(&mut bus, 0x77); // LD [HL] A
 
             assert_eq!(cycles, 8);
-            assert_eq!(bus.mem[0x1234], 0x01);
+            assert_eq!(bus.read(0x1234), 0x01);
             assert_eq!(cpu.registers.a, 0x01);
         }
 
@@ -279,13 +283,13 @@ mod tests {
 
             cpu.registers.e = 0x12;
             cpu.pc = 0x0034;
-            bus.mem[0x0034] = 0x56;
+            bus.write(0x0034, 0x56);
             let cycles = cpu.execute_instruction(&mut bus, 0x1E); // LD E n8
 
             assert_eq!(cycles, 8);
             assert_eq!(cpu.pc, 0x35);
             assert_eq!(cpu.registers.e, 0x56);
-            assert_eq!(bus.mem[0x0034], 0x56);
+            assert_eq!(bus.read(0x0034), 0x56);
         }
 
         #[test]
@@ -296,16 +300,16 @@ mod tests {
             cpu.registers.h = 0x12;
             cpu.registers.l = 0x34;
             cpu.pc = 0x0034;
-            bus.mem[0x0034] = 0x56;
-            bus.mem[0x1234] = 0x78;
+            bus.write(0x0034, 0x56);
+            bus.write(0x1234, 0x78);
             let cycles = cpu.execute_instruction(&mut bus, 0x36); // LD [HL] n8
 
             assert_eq!(cycles, 12);
             assert_eq!(cpu.pc, 0x35);
             assert_eq!(cpu.registers.h, 0x12);
             assert_eq!(cpu.registers.l, 0x34);
-            assert_eq!(bus.mem[0x1234], 0x56);
-            assert_eq!(bus.mem[0x0034], 0x56);
+            assert_eq!(bus.read(0x1234), 0x56);
+            assert_eq!(bus.read(0x0034), 0x56);
         }
 
         #[test]
@@ -315,12 +319,12 @@ mod tests {
 
             cpu.registers.b = 0x12;
             cpu.registers.c = 0x34;
-            bus.mem[0x1234] = 0x56;
+            bus.write(0x1234, 0x56);
             let cycles = cpu.execute_instruction(&mut bus, 0x0A); // LD A [BC]
 
             assert_eq!(cycles, 8);
             assert_eq!(cpu.registers.a, 0x56);
-            assert_eq!(bus.mem[0x1234], 0x56);
+            assert_eq!(bus.read(0x1234), 0x56);
         }
 
         #[test]
@@ -330,12 +334,12 @@ mod tests {
 
             cpu.registers.d = 0x12;
             cpu.registers.e = 0x34;
-            bus.mem[0x1234] = 0x56;
+            bus.write(0x1234, 0x56);
             let cycles = cpu.execute_instruction(&mut bus, 0x1A); // LD A [DE]
 
             assert_eq!(cycles, 8);
             assert_eq!(cpu.registers.a, 0x56);
-            assert_eq!(bus.mem[0x1234], 0x56);
+            assert_eq!(bus.read(0x1234), 0x56);
         }
 
         #[test]
@@ -345,13 +349,13 @@ mod tests {
 
             cpu.registers.h = 0x12;
             cpu.registers.l = 0x34;
-            bus.mem[0x1234] = 0x56;
+            bus.write(0x1234, 0x56);
 
             let cycles = cpu.execute_instruction(&mut bus, 0x2A); // LD A [HL+]
 
             assert_eq!(cycles, 8);
             assert_eq!(cpu.registers.a, 0x56);
-            assert_eq!(bus.mem[0x1234], 0x56);
+            assert_eq!(bus.read(0x1234), 0x56);
             assert_eq!(cpu.registers.hl_get(), 0x1235);
         }
 
@@ -362,12 +366,12 @@ mod tests {
 
             cpu.registers.d = 0x12;
             cpu.registers.e = 0x34;
-            bus.mem[0x1234] = 0x56;
+            bus.write(0x1234, 0x56);
             cpu.registers.a = 0x78;
             let cycles = cpu.execute_instruction(&mut bus, 0x12); // LD [DE] A
 
             assert_eq!(cycles, 8);
-            assert_eq!(bus.mem[0x1234], 0x78);
+            assert_eq!(bus.read(0x1234), 0x78);
             assert_eq!(cpu.registers.a, 0x78);
         }
 
@@ -378,12 +382,12 @@ mod tests {
 
             cpu.registers.h = 0x12;
             cpu.registers.l = 0x34;
-            bus.mem[0x1234] = 0x56;
+            bus.write(0x1234, 0x56);
             cpu.registers.a = 0x78;
             let cycles = cpu.execute_instruction(&mut bus, 0x32); // LD [HL-] A
 
             assert_eq!(cycles, 8);
-            assert_eq!(bus.mem[0x1234], 0x78);
+            assert_eq!(bus.read(0x1234), 0x78);
             assert_eq!(cpu.registers.a, 0x78);
             assert_eq!(cpu.registers.hl_get(), 0x1233);
         }
@@ -394,12 +398,12 @@ mod tests {
             let mut bus = Bus::new();
 
             cpu.pc = 0x1234;
-            bus.mem[0x1234] = 0x56;
+            bus.write(0x1234, 0x56);
             cpu.registers.a = 0x78;
             let cycles = cpu.execute_instruction(&mut bus, 0xE0); // LD [0xFF00 + n8] A
 
             assert_eq!(cycles, 12);
-            assert_eq!(bus.mem[0xFF56], 0x78);
+            assert_eq!(bus.read(0xFF56), 0x78);
             assert_eq!(cpu.registers.a, 0x78);
             assert_eq!(cpu.pc, 0x1235);
         }
@@ -412,12 +416,12 @@ mod tests {
                 let mut bus = Bus::new();
 
                 cpu.registers.c = 0x34;
-                bus.mem[0xFF34] = 0x56;
+                bus.write(0xFF34, 0x56);
                 let cycles = cpu.execute_instruction(&mut bus, 0xF2); // LD A [0xFF00 + C]
 
                 assert_eq!(cycles, 8);
                 assert_eq!(cpu.registers.a, 0x56);
-                assert_eq!(bus.mem[0xFF34], 0x56);
+                assert_eq!(bus.read(0xFF34), 0x56);
             }
         }
 
@@ -428,12 +432,12 @@ mod tests {
 
             cpu.pc = 0x1234;
             bus.write_word(cpu.pc, 0x5678);
-            bus.mem[0x5678] = 0x9A;
+            bus.write(0x5678, 0x9A);
             let cycles = cpu.execute_instruction(&mut bus, 0xFA); // LD A [N16]
 
             assert_eq!(cycles, 16);
             assert_eq!(cpu.registers.a, 0x9A);
-            assert_eq!(bus.mem[0x5678], 0x9A);
+            assert_eq!(bus.read(0x5678), 0x9A);
             assert_eq!(cpu.pc, 0x1236);
         }
 
@@ -448,7 +452,7 @@ mod tests {
             let cycles = cpu.execute_instruction(&mut bus, 0xEA); // LD [N16] A
 
             assert_eq!(cycles, 16);
-            assert_eq!(bus.mem[0x5678], 0x9A);
+            assert_eq!(bus.read(0x5678), 0x9A);
             assert_eq!(cpu.registers.a, 0x9A);
             assert_eq!(cpu.pc, 0x1236);
         }
@@ -469,8 +473,8 @@ mod tests {
 
             assert_eq!(cycles, 12);
             assert_eq!(cpu.registers.bc_get(), 0x5678);
-            assert_eq!(bus.mem[0x1234], 0x78);
-            assert_eq!(bus.mem[0x1235], 0x56);
+            assert_eq!(bus.read(0x1234), 0x78);
+            assert_eq!(bus.read(0x1235), 0x56);
             assert_eq!(cpu.pc, 0x1236);
         }
 
@@ -486,8 +490,8 @@ mod tests {
 
             assert_eq!(cycles, 12);
             assert_eq!(cpu.registers.hl_get(), 0x5678);
-            assert_eq!(bus.mem[0x1234], 0x78);
-            assert_eq!(bus.mem[0x1235], 0x56);
+            assert_eq!(bus.read(0x1234), 0x78);
+            assert_eq!(bus.read(0x1235), 0x56);
             assert_eq!(cpu.pc, 0x1236);
         }
 
@@ -503,8 +507,8 @@ mod tests {
 
             assert_eq!(cycles, 12);
             assert_eq!(cpu.sp, 0x5678);
-            assert_eq!(bus.mem[0x1234], 0x78);
-            assert_eq!(bus.mem[0x1235], 0x56);
+            assert_eq!(bus.read(0x1234), 0x78);
+            assert_eq!(bus.read(0x1235), 0x56);
             assert_eq!(cpu.pc, 0x1236);
         }
 
@@ -631,7 +635,7 @@ mod tests {
             cpu.registers.a = 0b0011_1100;
             cpu.registers.h = 0x12;
             cpu.registers.l = 0x34;
-            bus.mem[0x1234] = 0b0000_1111;
+            bus.write(0x1234, 0b0000_1111);
             let cycles = cpu.execute_instruction(&mut bus, 0xB6); // OR [HL]
 
             assert_eq!(cycles, 8);
@@ -661,7 +665,7 @@ mod tests {
 
             cpu.registers.a = 0xFF;
             cpu.pc = 0x1234;
-            bus.mem[0x1234] = 0x01;
+            bus.write(0x1234, 0x01);
             let cycles = cpu.execute_instruction(&mut bus, 0xC6); // ADD N8
 
             assert_eq!(cycles, 8);
@@ -676,7 +680,7 @@ mod tests {
 
             cpu.registers.a = 0b0011_1100;
             cpu.pc = 0x1234;
-            bus.mem[0x1234] = 0b0000_1111;
+            bus.write(0x1234, 0b0000_1111);
             let cycles = cpu.execute_instruction(&mut bus, 0xEE); // XOR N8
 
             assert_eq!(cycles, 8);
@@ -919,8 +923,8 @@ mod tests {
             let cycles = cpu.execute_instruction(&mut bus, 0xD5); // PUSH DE
 
             assert_eq!(cycles, 16);
-            assert_eq!(bus.mem[0xFFFC], 0x34); // lo - E
-            assert_eq!(bus.mem[0xFFFD], 0x12); // hi - D
+            assert_eq!(bus.read(0xFFFC), 0x34); // lo - E
+            assert_eq!(bus.read(0xFFFD), 0x12); // hi - D
             assert_eq!(cpu.sp, 0xFFFC);
         }
 
@@ -939,8 +943,8 @@ mod tests {
             let cycles = cpu.execute_instruction(&mut bus, 0xF5); // PUSH AF
 
             assert_eq!(cycles, 16);
-            assert_eq!(bus.mem[0xFFF4], 0b1010_0000); // lo - F
-            assert_eq!(bus.mem[0xFFF5], 0x56); // hi - A
+            assert_eq!(bus.read(0xFFF4), 0b1010_0000); // lo - F
+            assert_eq!(bus.read(0xFFF5), 0x56); // hi - A
             assert_eq!(cpu.sp, 0xFFF4);
         }
 
@@ -950,8 +954,8 @@ mod tests {
             let mut bus = Bus::new();
 
             cpu.sp = 0xFFFC;
-            bus.mem[0xFFFC] = 0x34; // lo - C
-            bus.mem[0xFFFD] = 0x12; // hi - B
+            bus.write(0xFFFC, 0x34); // lo - C
+            bus.write(0xFFFD, 0x12); // hi - B
 
             let cycles = cpu.execute_instruction(&mut bus, 0xC1); // POP BC
 
@@ -966,8 +970,8 @@ mod tests {
             let mut bus = Bus::new();
 
             cpu.sp = 0xFFF2;
-            bus.mem[0xFFF2] = 0x34; // lo - L
-            bus.mem[0xFFF3] = 0x12; // hi - H
+            bus.write(0xFFF2, 0x34); // lo - L
+            bus.write(0xFFF3, 0x12); // hi - H
 
             let cycles = cpu.execute_instruction(&mut bus, 0xE1); // POP HL
 
@@ -989,7 +993,7 @@ mod tests {
                 let mut bus = Bus::new();
 
                 cpu.pc = 0x1234;
-                bus.mem[0x1234] = (-2_i8).cast_unsigned();
+                bus.write(0x1234, (-2_i8).cast_unsigned());
 
                 let cycles = cpu.execute_instruction(&mut bus, 0x18); // JR e8
 
@@ -1003,7 +1007,7 @@ mod tests {
                 let mut bus = Bus::new();
 
                 cpu.pc = 0x1234;
-                bus.mem[0x1234] = (-0x11_i8).cast_unsigned();
+                bus.write(0x1234, (-0x11_i8).cast_unsigned());
 
                 cpu.registers.flags.z = true;
                 let cycles = cpu.execute_instruction(&mut bus, 0x28); // JR Z e8
@@ -1012,7 +1016,7 @@ mod tests {
                 assert_eq!(cycles, 12);
                 assert_eq!(cpu.pc, 0x1224); // +1 from e8 fetch -11 from jr
 
-                bus.mem[0x1224] = 0x20;
+                bus.write(0x1224, 0x20);
 
                 cpu.registers.flags.z = false;
                 let cycles = cpu.execute_instruction(&mut bus, 0x28); // JR Z e8
@@ -1028,7 +1032,7 @@ mod tests {
                 let mut bus = Bus::new();
 
                 cpu.pc = 0x1234;
-                bus.mem[0x1234] = (-0x11_i8).cast_unsigned();
+                bus.write(0x1234, (-0x11_i8).cast_unsigned());
 
                 cpu.registers.flags.c = true;
                 let cycles = cpu.execute_instruction(&mut bus, 0x30); // JR NC e8
@@ -1037,7 +1041,7 @@ mod tests {
                 assert_eq!(cycles, 8);
                 assert_eq!(cpu.pc, 0x1235); // +1 from e8
 
-                bus.mem[0x1235] = 0x20;
+                bus.write(0x1235, 0x20);
 
                 cpu.registers.flags.c = false;
                 let cycles = cpu.execute_instruction(&mut bus, 0x30); // JR NC e8
@@ -1446,10 +1450,16 @@ mod tests {
         }
 
         #[test]
-        #[ignore = "requires interrupt handling -- not yet implemented"]
         fn HALT() {
-            // HALT 0x76
-            todo!()
+            let mut cpu = CPU::new();
+            let mut bus = Bus::new();
+
+            cpu.ime.enable_now();
+
+            let cycles = cpu.execute_instruction(&mut bus, 0x76); // HALT
+
+            assert_eq!(cycles, 4);
+            assert!(matches!(cpu.state, CPUState::Halted));
         }
 
         #[test]
@@ -1460,7 +1470,7 @@ mod tests {
             let cycles = cpu.execute_instruction(&mut bus, 0xFB); // EI
 
             assert_eq!(cycles, 4);
-            assert!(matches!(cpu.ime, IME::PendingEnable));
+            assert!(matches!(cpu.ime, IME::PendingEnable(1)));
         }
 
         #[test]
@@ -1528,7 +1538,7 @@ mod tests {
 
                 cpu.registers.h = 0x23;
                 cpu.registers.l = 0x45;
-                bus.mem[0x2345] = 0b0000_0100;
+                bus.write(0x2345, 0b0000_0100);
                 cpu.registers.flags.z = true;
 
                 let cycles = cpu.execute_instruction(&mut bus, 0xCB); // PREFIX
@@ -1655,12 +1665,12 @@ mod tests {
 
                 cpu.registers.h = 0x12;
                 cpu.registers.l = 0x34;
-                bus.mem[0x1234] = 0b1001_0110;
+                bus.write(0x1234, 0b1001_0110);
 
                 let cycles = cpu.execute_extended_instruction(&mut bus, 0x2E); // SRA [HL]
 
                 assert_eq!(cycles, 16);
-                assert_eq!(bus.mem[0x1234], 0b1100_1011); // bit 7 should remain unchanged
+                assert_eq!(bus.read(0x1234), 0b1100_1011); // bit 7 should remain unchanged
             }
 
             #[test]

--- a/emulators/gb/src/cpu/instructions/execute.rs
+++ b/emulators/gb/src/cpu/instructions/execute.rs
@@ -1,6 +1,8 @@
 use crate::cpu::CPU;
 use crate::cpu::alu;
 
+use crate::interrupts::InterruptBus;
+
 use super::condition::Condition;
 use super::operand::{Operand8, Operand16};
 
@@ -998,8 +1000,14 @@ impl CPU {
         0
     }
 
-    pub(crate) fn instr_halt(&self) -> u32 {
-        todo!()
+    pub(crate) fn instr_halt<IB: InterruptBus>(&mut self, interrupt_bus: &IB) -> u32 {
+        if self.ime.is_disabled() && !interrupt_bus.requested_interrupts().is_empty() {
+            self.state.halt_bug();
+        } else {
+            self.state.halt();
+        }
+
+        0
     }
 
     pub(crate) fn instr_stop(&self) -> u32 {
@@ -1152,7 +1160,9 @@ mod flag_mask {
 #[allow(non_snake_case)] // helps a lot for regs names
 mod tests {
     use crate::cpu::interrupts::IME;
-    use emu::mem::test_utilities::MockMemoryBus as Bus;
+    use crate::cpu::tests::MockInterruptBus as Bus;
+
+    use crate::cpu::state::CPUState;
 
     use super::*;
 
@@ -1329,8 +1339,8 @@ mod tests {
 
                 assert_eq!(cycles, 0);
                 assert_eq!(cpu.sp, 0xFFFA); // sp should have moved down by 2 again
-                assert_eq!(bus.mem[0xFFFA], 0b1010_0000); // F
-                assert_eq!(bus.mem[0xFFFB], 0x56); // A
+                assert_eq!(bus.read(0xFFFA), 0b1010_0000); // F
+                assert_eq!(bus.read(0xFFFB), 0x56); // A
             }
         }
 
@@ -1343,8 +1353,8 @@ mod tests {
                 let mut bus = Bus::new();
 
                 cpu.sp = 0xFFFE;
-                bus.mem[0xFFFE] = 0x34;
-                bus.mem[0xFFFF] = 0x12;
+                bus.write(0xFFFE, 0x34);
+                bus.write(0xFFFF, 0x12);
 
                 let cycles = cpu.instr_pop(&mut bus, R16StackParam::BC);
 
@@ -1359,8 +1369,8 @@ mod tests {
                 let mut bus = Bus::new();
 
                 cpu.sp = 0x0000;
-                bus.mem[0x0000] = 0b1010_1010; // F
-                bus.mem[0x0001] = 0x56; // A
+                bus.write(0x0000, 0b1010_1010); // F
+                bus.write(0x0001, 0x56); // A
 
                 let cycles = cpu.instr_pop(&mut bus, R16StackParam::AF);
 
@@ -1696,7 +1706,7 @@ mod tests {
             cpu.registers.a = 0b0011_1100;
             cpu.registers.h = 0x12;
             cpu.registers.l = 0x34;
-            bus.mem[0x1234] = 0b0000_1111;
+            bus.write(0x1234, 0b0000_1111);
 
             let cycles = cpu.instr_alu(&bus, ALUOperation::OR, R8Param::IndHL.into());
 
@@ -1736,7 +1746,7 @@ mod tests {
 
             cpu.registers.a = 0xFF;
             cpu.pc = 0x1234;
-            bus.mem[0x1234] = 0x01;
+            bus.write(0x1234, 0x01);
 
             let cycles = cpu.instr_alu(&bus, ALUOperation::ADD, ALU8Param::N8);
 
@@ -2234,12 +2244,12 @@ mod tests {
 
                 cpu.registers.h = 0x12;
                 cpu.registers.l = 0x34;
-                bus.mem[0x1234] = 0b1001_0110;
+                bus.write(0x1234, 0b1001_0110);
                 let cycles =
                     cpu.instr_ext_bit_shift(&mut bus, BitShiftOperation::SRL, R8Param::IndHL);
 
                 assert_eq!(cycles, 0);
-                assert_eq!(bus.mem[0x1234], 0b0100_1011);
+                assert_eq!(bus.read(0x1234), 0b0100_1011);
                 assert!(!cpu.registers.flags.z);
                 assert!(!cpu.registers.flags.n);
                 assert!(!cpu.registers.flags.h);
@@ -2369,13 +2379,13 @@ mod tests {
 
                     cpu.registers.h = 0x12;
                     cpu.registers.l = 0x34;
-                    bus.mem[0x1234] = 0b1001_0110;
+                    bus.write(0x1234, 0b1001_0110);
                     let cycles = cpu.instr_ext_bit(&bus, 6.try_into().unwrap(), R8Param::IndHL);
 
                     assert_eq!(cycles, 0);
                     assert_eq!(cpu.registers.h, 0x12);
                     assert_eq!(cpu.registers.l, 0x34);
-                    assert_eq!(bus.mem[0x1234], 0b1001_0110); // should not modify the value
+                    assert_eq!(bus.read(0x1234), 0b1001_0110); // should not modify the value
 
                     assert!(cpu.registers.flags.z);
                     assert!(!cpu.registers.flags.n);
@@ -2485,11 +2495,11 @@ mod tests {
 
                 cpu.registers.h = 0x12;
                 cpu.registers.l = 0x34;
-                bus.mem[0x1234] = 0b1001_0110;
+                bus.write(0x1234, 0b1001_0110);
                 let cycles = cpu.instr_ext_res(&mut bus, 7.try_into().unwrap(), R8Param::IndHL);
 
                 assert_eq!(cycles, 0);
-                assert_eq!(bus.mem[0x1234], 0b1001_0110 & !(1 << 7));
+                assert_eq!(bus.read(0x1234), 0b1001_0110 & !(1 << 7));
             }
         }
 
@@ -2575,11 +2585,11 @@ mod tests {
 
                 cpu.registers.h = 0x12;
                 cpu.registers.l = 0x34;
-                bus.mem[0x1234] = 0b1001_0110;
+                bus.write(0x1234, 0b1001_0110);
                 let cycles = cpu.instr_ext_set(&mut bus, 7.try_into().unwrap(), R8Param::IndHL);
 
                 assert_eq!(cycles, 0);
-                assert_eq!(bus.mem[0x1234], 0b1001_0110 | (1 << 7));
+                assert_eq!(bus.read(0x1234), 0b1001_0110 | (1 << 7));
             }
         }
     }
@@ -2641,10 +2651,45 @@ mod tests {
             assert!(cpu.registers.flags.c);
         }
 
-        #[test]
-        #[ignore = "requires interrupt handling -- not yet implemented"]
-        fn halt() {
-            todo!()
+        mod halt {
+            use crate::interrupts::Interrupt;
+
+            use super::*;
+
+            #[test]
+            fn ime_enabled_no_interrupt() {
+                let mut cpu = CPU::new();
+                let bus = Bus::new();
+
+                cpu.ime.enable_now();
+
+                let cycles = cpu.instr_halt(&bus);
+
+                assert_eq!(cycles, 0);
+                assert!(matches!(cpu.state, CPUState::Halted));
+            }
+
+            #[test]
+            fn ime_disabled_no_interrupt() {
+                let mut cpu = CPU::new();
+                let bus = Bus::new();
+
+                let cycles = cpu.instr_halt(&bus);
+
+                assert_eq!(cycles, 0);
+                assert!(matches!(cpu.state, CPUState::Halted));
+            }
+
+            #[test]
+            fn ime_disabled_with_interrupt() {
+                let mut cpu = CPU::new();
+                let bus = Bus::with_pending(Interrupt::VBlank);
+
+                let cycles = cpu.instr_halt(&bus);
+
+                assert_eq!(cycles, 0);
+                assert!(matches!(cpu.state, CPUState::HaltBug));
+            }
         }
 
         #[test]
@@ -2660,7 +2705,7 @@ mod tests {
             let cycles = cpu.instr_ei();
 
             assert_eq!(cycles, 0);
-            assert!(matches!(cpu.ime, IME::PendingEnable));
+            assert!(matches!(cpu.ime, IME::PendingEnable(1)));
         }
 
         #[test]

--- a/emulators/gb/src/cpu/instructions/execute.rs
+++ b/emulators/gb/src/cpu/instructions/execute.rs
@@ -1000,8 +1000,48 @@ impl CPU {
         0
     }
 
-    pub(crate) fn instr_halt<IB: InterruptBus>(&mut self, interrupt_bus: &IB) -> u32 {
-        if self.ime.is_disabled() && !interrupt_bus.requested_interrupts().is_empty() {
+    /// Halt the CPU until an interrupt occurs.
+    ///
+    /// This instruction sets the CPU into a low-power state until an interrupt is
+    /// triggered.
+    ///
+    /// # Halt Bug
+    ///
+    /// If interrupts are disabled and an interrupt is pending, the CPU enters a
+    /// "halt bug" state. The halt bug is a known quirk of the Game Boy CPU
+    /// where the program counter does not increment correctly after a HALT
+    /// instruction.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let mut cpu = CPU::new();
+    /// let mut bus = Bus::new();
+    ///
+    /// cpu.ime = IME::Enabled; // interrupts are enabled
+    /// bus.enable_interrupt(Interrupt::VBlank); // enable VBlank interrupt
+    ///
+    /// cpu.instr_halt(&bus); // CPU enters halt state and will wake when a VBlank interrupt occurs
+    ///
+    /// assert!(cpu.state.is_halted());
+    /// ```
+    ///
+    /// Halt bug example:
+    ///
+    /// ```ignore
+    /// let mut cpu = CPU::new();
+    /// let mut bus = Bus::new();
+    ///
+    /// cpu.ime = IME::Disabled; // interrupts are disabled
+    /// bus.enable_interrupt(Interrupt::VBlank); // enable VBlank interrupt
+    /// bus.request_interrupt(Interrupt::VBlank); // VBlank interrupt is pending
+    ///
+    /// cpu.instr_halt(&bus); // CPU enters halt bug state
+    ///
+    /// assert!(cpu.state.is_halt_bug());
+    /// ```
+    pub(crate) fn instr_halt<IB: InterruptBus>(&mut self, bus: &IB) -> u32 {
+        if self.ime.is_disabled() && !bus.pending_interrupts().is_empty() {
             self.state.halt_bug();
         } else {
             self.state.halt();
@@ -2681,7 +2721,35 @@ mod tests {
             }
 
             #[test]
-            fn ime_disabled_with_interrupt() {
+            fn ime_enabled_with_not_enabled_interrupt() {
+                let mut cpu = CPU::new();
+                let mut bus = Bus::new();
+
+                cpu.ime.enable_now();
+
+                bus.request_interrupt(Interrupt::VBlank);
+
+                let cycles = cpu.instr_halt(&bus);
+
+                assert_eq!(cycles, 0);
+                assert!(matches!(cpu.state, CPUState::Halted));
+            }
+
+            #[test]
+            fn ime_disabled_with_not_enabled_interrupt() {
+                let mut cpu = CPU::new();
+                let mut bus = Bus::new();
+
+                bus.request_interrupt(Interrupt::VBlank);
+
+                let cycles = cpu.instr_halt(&bus);
+
+                assert_eq!(cycles, 0);
+                assert!(matches!(cpu.state, CPUState::Halted)); // this doesn't cause a halt bug because the interrupt in not enabled
+            }
+
+            #[test]
+            fn ime_disabled_with_pending_interrupt() {
                 let mut cpu = CPU::new();
                 let bus = Bus::with_pending(Interrupt::VBlank);
 

--- a/emulators/gb/src/cpu/interrupts.rs
+++ b/emulators/gb/src/cpu/interrupts.rs
@@ -129,7 +129,7 @@ mod tests {
         }
 
         #[test]
-        fn ime_commit_pending_noop() {
+        fn ime_tick_noop() {
             let mut ime = IME::Disabled;
             ime.tick();
             assert_eq!(ime, IME::Disabled);

--- a/emulators/gb/src/cpu/interrupts.rs
+++ b/emulators/gb/src/cpu/interrupts.rs
@@ -44,7 +44,7 @@ impl From<Interrupt> for InterruptJumpVector {
 pub enum IME {
     /// IME flag is reset, and will be set after the next
     /// instruction is executed.
-    PendingEnable(u8), // we had to use a counter as the cpu `step` function calls the `commit_pending` function twice when the IME needs to be enabled
+    PendingEnable(u8), // `EI` own step counts as a cycle, so we had to add a counter to track the number of cycles before enabling IME.
 
     /// IME flag is set.
     Enabled,
@@ -71,12 +71,13 @@ impl IME {
         *self = Self::Enabled;
     }
 
+    /// Tick the IME flag.
+    ///
     /// Transition from `PendingEnable` to `Enabled`. No-op in other states.
     ///
     /// Call once per CPU step, after instruction execution, to honour the one
     /// cycle delay introduced by the EI instruction.
-    // TODO: i really dislike this name
-    pub const fn commit_pending(&mut self) {
+    pub const fn tick(&mut self) {
         if matches!(self, Self::PendingEnable(0)) {
             *self = Self::Enabled;
         } else if let Self::PendingEnable(n) = self {
@@ -107,9 +108,9 @@ mod tests {
             let mut ime = IME::Disabled;
             ime.enable();
             assert_eq!(ime, IME::PendingEnable(1));
-            ime.commit_pending();
+            ime.tick();
             assert_eq!(ime, IME::PendingEnable(0));
-            ime.commit_pending();
+            ime.tick();
             assert_eq!(ime, IME::Enabled);
         }
 
@@ -130,11 +131,11 @@ mod tests {
         #[test]
         fn ime_commit_pending_noop() {
             let mut ime = IME::Disabled;
-            ime.commit_pending();
+            ime.tick();
             assert_eq!(ime, IME::Disabled);
 
             ime.enable_now();
-            ime.commit_pending();
+            ime.tick();
             assert_eq!(ime, IME::Enabled);
         }
     }

--- a/emulators/gb/src/cpu/interrupts.rs
+++ b/emulators/gb/src/cpu/interrupts.rs
@@ -44,7 +44,7 @@ impl From<Interrupt> for InterruptJumpVector {
 pub enum IME {
     /// IME flag is reset, and will be set after the next
     /// instruction is executed.
-    PendingEnable,
+    PendingEnable(u8), // we had to use a counter as the cpu `step` function calls the `commit_pending` function twice when the IME needs to be enabled
 
     /// IME flag is set.
     Enabled,
@@ -57,7 +57,7 @@ impl IME {
     /// Enable the IME flag after the next instruction is executed. Default
     /// behavior of the EI instruction.
     pub const fn enable(&mut self) {
-        *self = Self::PendingEnable;
+        *self = Self::PendingEnable(1);
     }
 
     /// Disable the IME flag immediately.
@@ -73,12 +73,25 @@ impl IME {
 
     /// Transition from `PendingEnable` to `Enabled`. No-op in other states.
     ///
-    /// Call once per CPU step, after interrupt dispatch, to honour the one-cycle
-    /// delay introduced by the EI instruction.
+    /// Call once per CPU step, after instruction execution, to honour the one
+    /// cycle delay introduced by the EI instruction.
+    // TODO: i really dislike this name
     pub const fn commit_pending(&mut self) {
-        if matches!(self, Self::PendingEnable) {
+        if matches!(self, Self::PendingEnable(0)) {
             *self = Self::Enabled;
+        } else if let Self::PendingEnable(n) = self {
+            *self = Self::PendingEnable(*n - 1);
         }
+    }
+
+    /// Checks if the IME is in `Enabled` state.
+    pub const fn is_enabled(&self) -> bool {
+        matches!(self, Self::Enabled)
+    }
+
+    /// Checks if the IME is either in `Disabled` or `PendingEnable` state.
+    pub const fn is_disabled(&self) -> bool {
+        !self.is_enabled()
     }
 }
 
@@ -93,7 +106,9 @@ mod tests {
         fn ime_enable() {
             let mut ime = IME::Disabled;
             ime.enable();
-            assert_eq!(ime, IME::PendingEnable);
+            assert_eq!(ime, IME::PendingEnable(1));
+            ime.commit_pending();
+            assert_eq!(ime, IME::PendingEnable(0));
             ime.commit_pending();
             assert_eq!(ime, IME::Enabled);
         }

--- a/emulators/gb/src/cpu/interrupts.rs
+++ b/emulators/gb/src/cpu/interrupts.rs
@@ -1,6 +1,6 @@
 use crate::interrupts::Interrupt;
 
-pub const INTERRUPT_DISPATCH_CYCLES: u32 = 5;
+pub const INTERRUPT_DISPATCH_CYCLES: u32 = 20;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InterruptJumpVector(u16);

--- a/emulators/gb/src/cpu/state.rs
+++ b/emulators/gb/src/cpu/state.rs
@@ -1,6 +1,41 @@
+pub const HALTED_CYCLES: u32 = 4;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CPUState {
     Running,
     Halted,
+    HaltBug,
     // Stopped,
+}
+
+impl CPUState {
+    /// Wake the CPU from a halted state.
+    pub const fn wake(&mut self) {
+        *self = Self::Running;
+    }
+
+    /// Put the CPU into a halted state.
+    pub const fn halt(&mut self) {
+        *self = Self::Halted;
+    }
+
+    /// Put the CPU into a halt bug state.
+    ///
+    /// This state occurs when the CPU is halted while an interrupt is pending
+    /// and IME is disabled. In this state, the CPU will execute the next
+    /// instruction after the HALT instruction, but will not increment the
+    /// program counter after executing that instruction.
+    pub const fn halt_bug(&mut self) {
+        *self = Self::HaltBug;
+    }
+
+    /// Checks if the CPU is in a halted state.
+    pub const fn is_halted(self) -> bool {
+        matches!(self, Self::Halted)
+    }
+
+    /// Checks if the CPU is in a halt bug state.
+    pub const fn is_halt_bug(self) -> bool {
+        matches!(self, Self::HaltBug)
+    }
 }

--- a/emulators/gb/src/cpu/state.rs
+++ b/emulators/gb/src/cpu/state.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CPUState {
+    Running,
+    Halted,
+    // Stopped,
+}

--- a/emulators/gb/src/interrupts.rs
+++ b/emulators/gb/src/interrupts.rs
@@ -31,19 +31,41 @@ pub enum Interrupt {
 /// Implementors expose the combined state of the Interrupt Enable (IE) and
 /// Interrupt Flag (IF) registers so the CPU can determine which interrupt to
 /// service next and mark it as handled.
-///
-/// Priority follows GB hardware convention: `VBlank` > `LCDStat` > `Timer` > `Serial` > `Joypad`.
-pub trait InterruptLine {
-    /// Returns the highest priority enabled pending interrupt, if any. Returns `None`
-    /// if no enabled interrupts are pending.
+pub trait InterruptBus {
+    /// Returns the currently requested interrupts (IF register).
+    ///
+    /// This represents interrupts that have been triggered by hardware events
+    /// but may not yet be enabled for servicing.
     #[must_use]
-    fn pending_interrupt(&self) -> Option<Interrupt>;
+    fn requested_interrupts(&self) -> InterruptFlags;
+
+    /// Returns the currently enabled interrupts (IE register).
+    ///
+    /// This represents which interrupts are allowed to be serviced by the CPU.
+    /// Only interrupts that are both requested and enabled will be considered
+    /// pending and be serviced.
+    #[must_use]
+    fn enabled_interrupts(&self) -> InterruptFlags;
 
     /// Acknowledge an interrupt.
     ///
     /// This will typically involve clearing the corresponding bit in the IF
     /// register to indicate that the interrupt is being serviced.
     fn acknowledge_interrupt(&mut self, interrupt: Interrupt);
+
+    /// Returns the highest priority pending interrupt, or `None` if no
+    /// interrupts are pending.
+    #[must_use]
+    fn highest_pending_interrupt(&self) -> Option<Interrupt> {
+        self.pending_interrupts().highest_priority()
+    }
+
+    /// Returns the set of interrupts that are both requested and enabled,
+    /// i.e. the interrupts that are pending and should be serviced by the CPU.
+    #[must_use]
+    fn pending_interrupts(&self) -> InterruptFlags {
+        self.requested_interrupts() & self.enabled_interrupts()
+    }
 }
 
 impl InterruptFlags {

--- a/emulators/gb/src/motherboard.rs
+++ b/emulators/gb/src/motherboard.rs
@@ -2,7 +2,7 @@ mod interrupts;
 
 use emu::MemoryBus;
 
-use crate::interrupts::{Interrupt, InterruptLine};
+use crate::interrupts::{Interrupt, InterruptBus, InterruptFlags};
 use interrupts::{IE_ADDRESS, IF_ADDRESS, InterruptRegisters};
 
 #[derive(Debug)]
@@ -109,9 +109,13 @@ impl MemoryBus for MotherBoard {
     }
 }
 
-impl InterruptLine for MotherBoard {
-    fn pending_interrupt(&self) -> Option<Interrupt> {
-        self.interrupt_registers.pending_interrupt()
+impl InterruptBus for MotherBoard {
+    fn requested_interrupts(&self) -> InterruptFlags {
+        self.interrupt_registers.requested_interrupts()
+    }
+
+    fn enabled_interrupts(&self) -> InterruptFlags {
+        self.interrupt_registers.enabled_interrupts()
     }
 
     fn acknowledge_interrupt(&mut self, interrupt: Interrupt) {

--- a/emulators/gb/src/motherboard/interrupts.rs
+++ b/emulators/gb/src/motherboard/interrupts.rs
@@ -45,11 +45,11 @@ impl InterruptRegisters {
     /// interrupt_registers.request_interrupt(Interrupt::VBlank);
     /// assert_eq!(interrupt_registers.interrupt_flags, InterruptFlags::VBLANK);
     ///
-    /// assert_eq!(interrupt_registers.pending_interrupt(), None); // no interrupts enabled, so pending_interrupt returns None
+    /// assert_eq!(interrupt_registers.highest_pending_interrupt(), None); // no interrupts enabled, so highest_pending_interrupt returns None
     ///
     /// interrupt_registers.enable_interrupt(Interrupt::VBlank); // enable the VBlank interrupt (note that this function is only available for testing)
     ///
-    /// assert_eq!(interrupt_registers.pending_interrupt(), Some(Interrupt::VBlank)); // now pending_interrupt returns the VBlank interrupt, since it is enabled and pending
+    /// assert_eq!(interrupt_registers.highest_pending_interrupt(), Some(Interrupt::VBlank)); // now highest_pending_interrupt returns the VBlank interrupt, since it is enabled and pending
     /// ```
     #[allow(dead_code)] // this method is not used yet, but will be when we implement other components that trigger interrupts
     pub fn request_interrupt(&mut self, interrupt: Interrupt) {
@@ -79,12 +79,12 @@ impl InterruptBus for InterruptRegisters {
     /// interrupt_registers.request_interrupt(Interrupt::Timer);
     /// interrupt_registers.enable_interrupt(Interrupt::Timer);
     ///
-    /// assert_eq!(interrupt_registers.pending_interrupt(), Some(Interrupt::Timer)); // Timer interrupt is pending
+    /// assert_eq!(interrupt_registers.highest_pending_interrupt(), Some(Interrupt::Timer)); // Timer interrupt is pending
     ///
     /// // Acknowledge the Timer interrupt
     /// interrupt_registers.acknowledge_interrupt(Interrupt::Timer);
     ///
-    /// assert_eq!(interrupt_registers.pending_interrupt(), None); // no interrupts are pending after acknowledging
+    /// assert_eq!(interrupt_registers.highest_pending_interrupt(), None); // no interrupts are pending after acknowledging
     /// ```
     fn acknowledge_interrupt(&mut self, interrupt: Interrupt) {
         self.interrupt_flags &= !InterruptFlags::from(interrupt);

--- a/emulators/gb/src/motherboard/interrupts.rs
+++ b/emulators/gb/src/motherboard/interrupts.rs
@@ -1,4 +1,4 @@
-use crate::interrupts::{Interrupt, InterruptFlags, InterruptLine};
+use crate::interrupts::{Interrupt, InterruptBus, InterruptFlags};
 use emu::MemoryBus;
 
 /// Interrupt Registers, which include the Interrupt Enable (IE) and Interrupt Flags (IF) registers.
@@ -57,12 +57,15 @@ impl InterruptRegisters {
     }
 }
 
-impl InterruptLine for InterruptRegisters {
-    /// Returns the highest priority pending interrupt, if any. Returns `None`
-    /// if no enabled interrupts are pending.
-    fn pending_interrupt(&self) -> Option<Interrupt> {
-        let pending_interrupts = self.interrupt_enable & self.interrupt_flags;
-        pending_interrupts.highest_priority()
+impl InterruptBus for InterruptRegisters {
+    /// Returns the currently requested interrupts (IF register).
+    fn requested_interrupts(&self) -> InterruptFlags {
+        self.interrupt_flags
+    }
+
+    /// Returns the currently enabled interrupts (IE register).
+    fn enabled_interrupts(&self) -> InterruptFlags {
+        self.interrupt_enable
     }
 
     /// Acknowledge an interrupt and mark it as serviced.
@@ -183,14 +186,14 @@ mod tests {
         interrupt_registers.request_interrupt(Interrupt::Timer);
 
         // No interrupts enabled, so pending_interrupt should return None
-        assert_eq!(interrupt_registers.pending_interrupt(), None);
+        assert_eq!(interrupt_registers.highest_pending_interrupt(), None);
 
         // Enable the Timer interrupt
         interrupt_registers.enable_interrupt(Interrupt::Timer);
 
         // Now pending_interrupt should return the Timer interrupt
         assert_eq!(
-            interrupt_registers.pending_interrupt(),
+            interrupt_registers.highest_pending_interrupt(),
             Some(Interrupt::Timer)
         );
 
@@ -200,7 +203,7 @@ mod tests {
 
         // Now pending_interrupt should return the VBlank interrupt, since it has higher priority
         assert_eq!(
-            interrupt_registers.pending_interrupt(),
+            interrupt_registers.highest_pending_interrupt(),
             Some(Interrupt::VBlank)
         );
 
@@ -209,7 +212,7 @@ mod tests {
 
         // Now pending_interrupt should return the Timer interrupt, since the VBlank interrupt has been acknowledged
         assert_eq!(
-            interrupt_registers.pending_interrupt(),
+            interrupt_registers.highest_pending_interrupt(),
             Some(Interrupt::Timer)
         );
     }


### PR DESCRIPTION
## HALT instruction
- Add HALT instruction implementation
- Add HALT bug implementation that causes PC to not increment properly in rare occasions

## CPU
- Add CPUState module to track the current state of the CPU with states `Running`, `Halted` and `HaltBug`

## IME
- Rename `commit_pending` function to more generic `tick` name
- Fix EI latency error
  - IME enable latency was bugged, the IME was switched from Pending to Enabled just before the next instruction executes which would cause the next instruction to already see the IME as enabled
  - Move IME tick function call from **before** instruction execution to **after** instruction execution
  - Add a counter to track the number of calls to the now `tick` function to be sure that the latency is properly implemented

## InterruptLine
- Rename InterruptLine trait into InterruptBus 
- Change InterruptLine API to expose the requested and enabled interrupts
  - Pending and highest priority pending interrupts are now deduced in the InterruptLine trait
