### PR TITLE
refactor(gb): improve cpu registers creation

### DIFF
--- a/emulators/gb/src/cpu.rs
+++ b/emulators/gb/src/cpu.rs
@@ -43,7 +43,10 @@ pub struct CPU {
 }
 
 impl CPU {
-    pub(crate) fn new() -> Self {
+    /// Create a new [`CPU`] with all fields set to `0`.
+    ///
+    /// [`CPU::ime`] is set to [`IME::Disabled`] and [`CPU::state`] is set to [`CPUState::Running`].
+    pub(crate) const fn new() -> Self {
         Self {
             registers: Registers::new(),
             sp: 0x00,

--- a/emulators/gb/src/cpu/registers.rs
+++ b/emulators/gb/src/cpu/registers.rs
@@ -44,8 +44,17 @@ impl Registers {
     /// assert_eq!(regs.a, 0x00);
     /// assert!(!regs.flags.z);
     /// ```
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            a: 0,
+            flags: Flags::new(),
+            b: 0,
+            c: 0,
+            d: 0,
+            e: 0,
+            h: 0,
+            l: 0,
+        }
     }
 
     /// Returns the value stored in the 16-bit register pair `BC`.
@@ -277,8 +286,14 @@ pub struct Flags {
 }
 
 impl Flags {
-    pub fn new() -> Self {
-        Self::default()
+    /// Create a new [`Flags`] register with all flags set to `false`.
+    pub const fn new() -> Self {
+        Self {
+            z: false,
+            n: false,
+            h: false,
+            c: false,
+        }
     }
 }
 

--- a/emulators/gb/src/lib.rs
+++ b/emulators/gb/src/lib.rs
@@ -14,7 +14,7 @@ pub struct GameBoy {
 
 impl GameBoy {
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             cpu: CPU::new(),
             mb: MotherBoard::new(),


### PR DESCRIPTION
- Swapped cpu registers and flags `new` with the `default` derive implementation.
- CPU's new function could now be marked as const

Closes #31 